### PR TITLE
Add Dynamic DNS (DDNS) support for Kea 3.0+

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,35 @@
 # Changelog
 
+## 0.8.0 (2026-04-26)
+
+### Added — Dynamic DNS (DDNS) support for Kea 3.0+
+Models the full `kea-dhcp-ddns` (D2) configuration surface and the per-server / per-subnet / per-class `ddns-*` knobs that `kea-dhcp4`/`kea-dhcp6` can render. Gated behind the `enable_ddns` plugin setting (which requires `enable_netbox_dns=True` — TSIG keys are plugin-local but zones and nameservers come from `netbox-plugin-dns`).
+
+- **New models**
+  - `TSIGKey` — RFC 2845 keys with algorithm choices, optional digest-bits truncation, and a pluggable `secret_backend` registry (v1 ships `plaintext`; `vault` reserved for future). Secret values are auto-generated on save when input is empty or not algorithm-length base64 — paste `tsig-keygen` output verbatim or just save and let the plugin mint one. Plaintext reveal is gated by a dedicated `view_secret_tsigkey` permission.
+  - `D2Daemon` — one row per logical D2 service. `listener_mode` chooses between `local` (renders `127.0.0.1`; deploy one D2 instance per peer for HA-pair DDNS redundancy) and `remote` (single shared instance pinned to an IPAM record). Includes NCR transport, control-socket path (defaults from `d2_default_control_socket_path` plugin setting), and a per-daemon `/api/.../d2-daemons/<id>/kea-config/` endpoint that emits a complete `kea-dhcp-ddns.conf`.
+  - `DDNSDomain` — binds a `D2Daemon` to a `netbox_dns.Zone`. Forward/reverse direction is derived from the zone name at emission time. Authoritative nameserver IPs are resolved from the zone's `NameServer` records (A/AAAA/CNAME chain) at config-emit time. Create form is multi-zone — pick any combination of forward and reverse zones in one shot.
+  - `DDNSPolicy` — reusable `ddns-*` override group (`ddns-send-updates`, `ddns-override-no-update`, `ddns-replace-client-name`, `ddns-generated-prefix`/`-qualifying-suffix`, `hostname-char-set`/`-replacement`, conflict-resolution mode, TTL knobs). All fields nullable — `to_kea_overrides()` emits only the keys the operator set, kebab-cased.
+
+- **Existing model changes** (all nullable FKs, `on_delete=SET_NULL`)
+  - `DHCPServer.d2_daemon`, `ddns_enable_updates`, `ddns_sender_ip`, `ddns_sender_port`, `ddns_policy`
+  - `DHCPHARelationship.d2_daemon`, `ddns_enable_updates`, `ddns_policy`
+  - `Subnet.ddns_policy`
+  - `ClientClass.ddns_policy`
+
+- **HA-pair precedence** — `DHCPServer.effective_d2_daemon` and `effective_ddns_policy` properties: when the server's HA relationship has a value set, that wins (peers must agree on the D2 target and the `ddns-*` policy). Sender IP/port stay per-server (the local source endpoint is always per-host). The DHCPServer detail page shows the effective values with an "inherited from HA relationship" badge.
+
+- **Kea config emission** — no Python-side merging of override hierarchies. Each non-null `DDNSPolicy.to_kea_overrides()` is emitted verbatim at the JSON level the policy is attached to (server-level → `Dhcp4`/`Dhcp6` root, subnet-level → subnet dict, class-level → client-class dict). Kea resolves the precedence chain itself when processing packets.
+
+- **Bulk edit** — `DDNSDomain` got a bulk-edit view + form so you can set `d2_daemon` / `tsig_key` on many rows at once.
+
+- **Quick-add** — `tsig_key` field on `DDNSDomain` form has the `+` quick-add button so a new TSIG key can be created inline without leaving the form.
+
+### Plugin settings
+- `enable_ddns` (default `False`) — master switch; nav, URLs, API routes, form fields, and serializer fields are all gated by it.
+- `ddns_secret_backend` (default `"plaintext"`) — backend identifier for `TSIGKey.get_secret()`.
+- `d2_default_control_socket_path` (default `"/tmp/kea-dhcp-ddns-ctrl.sock"`) — pre-fills the control socket field on new `D2Daemon` rows.
+
 ## 0.7.3 (2026-04-07)
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ This plugin bridges the gap between NetBox IPAM and ISC KEA DHCP server configur
 - **HA Relationships**: Configure High Availability relationships between DHCP servers
 - **Stork Servers**: Manage ISC Stork monitoring server instances
 - **Stork Agent Groups**: Configure Stork agent groups that link DHCP servers to a Stork monitoring server
+- **TSIG Keys, D2 Daemons, DDNS Domains, DDNS Policies**: Optional Kea 3.0+ Dynamic DNS modelling (see [Dynamic DNS (DDNS)](#dynamic-dns-ddns))
 
 ### Stork Monitoring Integration
 
@@ -41,6 +42,26 @@ This plugin bridges the gap between NetBox IPAM and ISC KEA DHCP server configur
 - TLS and authentication options for Stork server connections
 - Stork features are fully optional — disable with `enable_stork: False` in plugin settings
 - API endpoints support `Accept: text/plain` for easy integration with Ansible `uri` module
+
+### Dynamic DNS (DDNS)
+
+Optional Kea 3.0+ Dynamic DNS support — model `kea-dhcp-ddns` (D2) instances, TSIG keys, forward/reverse zones, and the `ddns-*` policy knobs that `kea-dhcp4`/`kea-dhcp6` render at server / subnet / client-class scope.
+
+DDNS support is **disabled by default** and requires `enable_netbox_dns: True` (zones and nameservers are sourced from [`netbox-plugin-dns`](https://github.com/peteeckel/netbox-plugin-dns); TSIG keys are plugin-local). Enable with `enable_ddns: True` in `PLUGINS_CONFIG` (see [Configuration](#configuration)) — when off, the navigation entries, URLs, API routes, and form fields are all hidden.
+
+- **Models**
+  - `TSIGKey` — RFC 2845 keys with algorithm choices (`HMAC-MD5`/`SHA1`/`SHA224`/`SHA256`/`SHA384`/`SHA512`), optional digest-bits truncation, and a pluggable `secret_backend` registry (v1 ships `plaintext`; `vault` reserved). Secret values are auto-generated on save when input is empty or not algorithm-length base64 — you can paste `tsig-keygen` output verbatim or just save and let the plugin mint a fresh one. Plaintext reveal is gated by a dedicated `view_secret_tsigkey` permission.
+  - `D2Daemon` — one row per logical D2 service. `listener_mode` chooses between **local** (renders `127.0.0.1`; deploy one D2 instance per peer for HA-pair DDNS redundancy) and **remote** (single shared instance pinned to an IPAM record). Each daemon exposes a per-instance `/api/plugins/netbox_dhcp_kea_plugin/d2-daemons/<id>/kea-config/` endpoint that emits a complete `kea-dhcp-ddns.conf`.
+  - `DDNSDomain` — binds a `D2Daemon` to a `netbox_dns.Zone`. Forward/reverse direction is derived from the zone name at emission time. Authoritative nameserver IPs are resolved from the zone's `NameServer` records (A/AAAA/CNAME chain) when the config is rendered. The create form is multi-zone — pick any combination of forward and reverse zones in one shot.
+  - `DDNSPolicy` — reusable `ddns-*` override group attachable at server / subnet / client-class scope (`ddns-send-updates`, `ddns-override-no-update`, `ddns-replace-client-name`, `ddns-generated-prefix`/`-qualifying-suffix`, `hostname-char-set`/`-replacement`, conflict-resolution mode, TTL knobs). All fields nullable — only the keys you set are emitted, kebab-cased.
+
+- **HA-pair precedence** — when a `DHCPServer` is in an HA relationship and the relationship has its own `d2_daemon` or `ddns_policy` set, the relationship's value wins (peers must agree on the D2 target and the policy knobs). Sender IP/port stay per-server because the local source endpoint is per-host. The DHCPServer detail page shows the effective values with an "inherited from HA relationship" badge.
+
+- **Local-D2 redundancy pattern (recommended for HA)** — set `listener_mode: local` on the `D2Daemon` shared by an HA pair, then deploy `kea-dhcp-ddns` on every peer host with the same rendered config. Each peer's `kea-dhcp4`/`6` posts NCRs to its own `127.0.0.1:53001`. If the active peer reboots, the standby's local D2 takes over with no DDNS gap.
+
+- **Kea config emission** — no Python-side merging of override hierarchies. Each non-null `DDNSPolicy.to_kea_overrides()` is emitted verbatim at the JSON level the policy is attached to (server-level → `Dhcp4`/`Dhcp6` root, subnet-level → subnet dict, class-level → client-class dict). Kea resolves the precedence chain itself when processing packets.
+
+- **Bulk edit + quick-add** — `DDNSDomain` has a bulk-edit form (set `d2_daemon` / `tsig_key` on many rows at once), and the `tsig_key` field on the DDNS Domain form has a `+` quick-add button so a new TSIG key can be created inline without leaving the form.
 
 ### High Availability (HA) Support
 

--- a/netbox_dhcp_kea_plugin/__init__.py
+++ b/netbox_dhcp_kea_plugin/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = """Łukasz Polański"""
 __email__ = "wookasz@gmail.com"
-__version__ = "0.7.3"
+__version__ = "0.8.0"
 
 
 from netbox.plugins import PluginConfig

--- a/netbox_dhcp_kea_plugin/__init__.py
+++ b/netbox_dhcp_kea_plugin/__init__.py
@@ -24,6 +24,7 @@ class DHCPKEAConfig(PluginConfig):
         "enable_netbox_dns": False,
         "enable_ddns": False,
         "ddns_secret_backend": "plaintext",
+        "d2_default_control_socket_path": "/tmp/kea-dhcp-ddns-ctrl.sock",
         "model_defaults": {
             "Subnet": {
                 "valid_lifetime": 3600,

--- a/netbox_dhcp_kea_plugin/__init__.py
+++ b/netbox_dhcp_kea_plugin/__init__.py
@@ -22,6 +22,8 @@ class DHCPKEAConfig(PluginConfig):
         "menu_name": "DHCP KEA",
         "enable_stork": True,
         "enable_netbox_dns": False,
+        "enable_ddns": False,
+        "ddns_secret_backend": "plaintext",
         "model_defaults": {
             "Subnet": {
                 "valid_lifetime": 3600,
@@ -98,6 +100,35 @@ class DHCPKEAConfig(PluginConfig):
 
         # Protect IP sources from deletion — GenericFK has no DB-level constraint
         self._register_ip_source_protection()
+
+        # DDNS depends on netbox-dns for Zone and NameServer objects
+        self._validate_ddns_dependencies()
+
+    @staticmethod
+    def _validate_ddns_dependencies():
+        """Raise if enable_ddns=True but netbox-dns isn't available."""
+        from django.conf import settings
+        from django.core.exceptions import ImproperlyConfigured
+
+        cfg = settings.PLUGINS_CONFIG.get("netbox_dhcp_kea_plugin", {})
+        if not cfg.get("enable_ddns"):
+            return
+
+        if not cfg.get("enable_netbox_dns"):
+            raise ImproperlyConfigured(
+                "netbox_dhcp_kea_plugin: enable_ddns=True requires "
+                "enable_netbox_dns=True — DDNS zones and nameservers are "
+                "pulled from the netbox-plugin-dns integration."
+            )
+
+        try:
+            import netbox_dns  # noqa: F401
+        except ImportError as exc:
+            raise ImproperlyConfigured(
+                "netbox_dhcp_kea_plugin: enable_ddns=True but "
+                "netbox_dns could not be imported. Install netbox-plugin-dns "
+                "and add it to PLUGINS."
+            ) from exc
 
     @staticmethod
     def _register_ip_source_protection():

--- a/netbox_dhcp_kea_plugin/api/serializers.py
+++ b/netbox_dhcp_kea_plugin/api/serializers.py
@@ -482,8 +482,7 @@ class DHCPHARelationshipSerializer(NetBoxModelSerializer):
             "servers",
             "d2_daemon",
             "ddns_enable_updates",
-            "ddns_sender_ip",
-            "ddns_sender_port",
+            "ddns_policy",
             "tags",
             "custom_fields",
             "created",
@@ -493,7 +492,7 @@ class DHCPHARelationshipSerializer(NetBoxModelSerializer):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         if not get_plugin_config("netbox_dhcp_kea_plugin", "enable_ddns"):
-            for f in ("d2_daemon", "ddns_enable_updates", "ddns_sender_ip", "ddns_sender_port"):
+            for f in ("d2_daemon", "ddns_enable_updates", "ddns_policy"):
                 self.fields.pop(f, None)
 
     def get_d2_daemon(self, obj):

--- a/netbox_dhcp_kea_plugin/api/serializers.py
+++ b/netbox_dhcp_kea_plugin/api/serializers.py
@@ -7,6 +7,9 @@ from rest_framework import serializers
 
 from ..models import (
     ClientClass,
+    D2Daemon,
+    DDNSDomain,
+    DDNSPolicy,
     DHCPHARelationship,
     DHCPServer,
     Hook,
@@ -18,6 +21,7 @@ from ..models import (
     StorkServer,
     Subnet,
     SubnetPool,
+    TSIGKey,
     VendorOptionSpace,
 )
 
@@ -232,6 +236,9 @@ class DHCPServerSerializer(NetBoxModelSerializer):
     ha_relationship = serializers.SerializerMethodField()
     ha_url = serializers.SerializerMethodField()
     stork_agent_group = NestedStorkAgentGroupSerializer(read_only=True)
+    d2_daemon = serializers.SerializerMethodField()
+    effective_d2_daemon = serializers.SerializerMethodField()
+    ddns_policy = serializers.SerializerMethodField()
 
     class Meta:
         model = DHCPServer
@@ -259,6 +266,12 @@ class DHCPServerSerializer(NetBoxModelSerializer):
             "ha_basic_auth_user",
             "ha_basic_auth_password",
             "stork_agent_group",
+            "d2_daemon",
+            "effective_d2_daemon",
+            "ddns_enable_updates",
+            "ddns_sender_ip",
+            "ddns_sender_port",
+            "ddns_policy",
             "ctrl_socket_type",
             "ctrl_socket_http_address",
             "ctrl_socket_http_port",
@@ -273,6 +286,39 @@ class DHCPServerSerializer(NetBoxModelSerializer):
         super().__init__(*args, **kwargs)
         if not get_plugin_config("netbox_dhcp_kea_plugin", "enable_stork"):
             self.fields.pop("stork_agent_group", None)
+        if not get_plugin_config("netbox_dhcp_kea_plugin", "enable_ddns"):
+            for f in (
+                "d2_daemon",
+                "effective_d2_daemon",
+                "ddns_enable_updates",
+                "ddns_sender_ip",
+                "ddns_sender_port",
+                "ddns_policy",
+            ):
+                self.fields.pop(f, None)
+
+    def _daemon_dict(self, daemon):
+        if daemon is None:
+            return None
+        return {"id": daemon.id, "name": daemon.name}
+
+    def get_d2_daemon(self, obj):
+        return self._daemon_dict(obj.d2_daemon)
+
+    def get_effective_d2_daemon(self, obj):
+        daemon = obj.effective_d2_daemon
+        if daemon is None:
+            return None
+        result = self._daemon_dict(daemon)
+        result["inherited_from_ha_relationship"] = bool(
+            obj.ha_relationship_id and obj.ha_relationship.d2_daemon_id == daemon.id
+        )
+        return result
+
+    def get_ddns_policy(self, obj):
+        if obj.ddns_policy is None:
+            return None
+        return {"id": obj.ddns_policy.id, "name": obj.ddns_policy.name}
 
     def get_ha_url(self, obj):
         return obj.ha_url
@@ -290,6 +336,7 @@ class DHCPServerSerializer(NetBoxModelSerializer):
 class ClientClassSerializer(NetBoxModelSerializer):
     url = serializers.HyperlinkedIdentityField(view_name="plugins-api:netbox_dhcp_kea_plugin-api:clientclass-detail")
     option_data = OptionDataSerializer(many=True, read_only=True)
+    ddns_policy = serializers.SerializerMethodField()
 
     class Meta:
         model = ClientClass
@@ -305,11 +352,22 @@ class ClientClassSerializer(NetBoxModelSerializer):
             "next_server",
             "server_hostname",
             "boot_file_name",
+            "ddns_policy",
             "tags",
             "custom_fields",
             "created",
             "last_updated",
         )
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        if not get_plugin_config("netbox_dhcp_kea_plugin", "enable_ddns"):
+            self.fields.pop("ddns_policy", None)
+
+    def get_ddns_policy(self, obj):
+        if obj.ddns_policy is None:
+            return None
+        return {"id": obj.ddns_policy.id, "name": obj.ddns_policy.name}
 
 
 class SubnetSerializer(NetBoxModelSerializer):
@@ -320,6 +378,7 @@ class SubnetSerializer(NetBoxModelSerializer):
     client_class = NestedClientClassSerializer(read_only=True)
     evaluate_additional_classes = NestedClientClassSerializer(many=True, read_only=True)
     router_ip = serializers.SerializerMethodField()
+    ddns_policy = serializers.SerializerMethodField()
 
     class Meta:
         model = Subnet
@@ -340,15 +399,26 @@ class SubnetSerializer(NetBoxModelSerializer):
             "reservations_in_subnet",
             "reservations_out_of_pool",
             "reservations_only",
+            "ddns_policy",
             "tags",
             "custom_fields",
             "created",
             "last_updated",
         )
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        if not get_plugin_config("netbox_dhcp_kea_plugin", "enable_ddns"):
+            self.fields.pop("ddns_policy", None)
+
     def get_router_ip(self, obj):
         """Return the calculated router IP address."""
         return obj.get_router_ip()
+
+    def get_ddns_policy(self, obj):
+        if obj.ddns_policy is None:
+            return None
+        return {"id": obj.ddns_policy.id, "name": obj.ddns_policy.name}
 
 
 class SubnetPoolSerializer(NetBoxModelSerializer):
@@ -389,6 +459,7 @@ class DHCPHARelationshipSerializer(NetBoxModelSerializer):
         view_name="plugins-api:netbox_dhcp_kea_plugin-api:dhcpharelationship-detail"
     )
     servers = NestedDHCPServerSerializer(many=True, read_only=True)
+    d2_daemon = serializers.SerializerMethodField()
 
     class Meta:
         model = DHCPHARelationship
@@ -409,11 +480,26 @@ class DHCPHARelationshipSerializer(NetBoxModelSerializer):
             "http_client_threads",
             "description",
             "servers",
+            "d2_daemon",
+            "ddns_enable_updates",
+            "ddns_sender_ip",
+            "ddns_sender_port",
             "tags",
             "custom_fields",
             "created",
             "last_updated",
         )
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        if not get_plugin_config("netbox_dhcp_kea_plugin", "enable_ddns"):
+            for f in ("d2_daemon", "ddns_enable_updates", "ddns_sender_ip", "ddns_sender_port"):
+                self.fields.pop(f, None)
+
+    def get_d2_daemon(self, obj):
+        if obj.d2_daemon is None:
+            return None
+        return {"id": obj.d2_daemon.id, "name": obj.d2_daemon.name}
 
 
 class NestedStorkServerSerializer(WritableNestedSerializer):
@@ -494,3 +580,143 @@ class StorkAgentGroupSerializer(NetBoxModelSerializer):
     def get_servers(self, obj):
         servers = obj.servers.all()
         return NestedDHCPServerSerializer(servers, many=True, context=self.context).data
+
+
+# --- DDNS Serializers ---
+
+
+class NestedTSIGKeySerializer(WritableNestedSerializer):
+    class Meta:
+        model = TSIGKey
+        fields = ["id", "url", "display", "name", "algorithm"]
+
+
+class NestedD2DaemonSerializer(WritableNestedSerializer):
+    class Meta:
+        model = D2Daemon
+        fields = ["id", "url", "display", "name", "port"]
+
+
+class NestedDDNSPolicySerializer(WritableNestedSerializer):
+    class Meta:
+        model = DDNSPolicy
+        fields = ["id", "url", "display", "name"]
+
+
+class TSIGKeySerializer(NetBoxModelSerializer):
+    url = serializers.HyperlinkedIdentityField(view_name="plugins-api:netbox_dhcp_kea_plugin-api:tsigkey-detail")
+
+    class Meta:
+        model = TSIGKey
+        fields = (
+            "id",
+            "url",
+            "display",
+            "name",
+            "description",
+            "algorithm",
+            "digest_bits",
+            "secret_backend",
+            "secret_plaintext",
+            "secret_ref",
+            "tags",
+            "custom_fields",
+            "created",
+            "last_updated",
+        )
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        request = self.context.get("request") if self.context else None
+        if request is None or not request.user.has_perm("netbox_dhcp_kea_plugin.view_secret_tsigkey"):
+            self.fields.pop("secret_plaintext", None)
+
+
+class D2DaemonSerializer(NetBoxModelSerializer):
+    url = serializers.HyperlinkedIdentityField(view_name="plugins-api:netbox_dhcp_kea_plugin-api:d2daemon-detail")
+    ip_address = IPAddressSerializer(nested=True, read_only=True)
+    domains_count = serializers.SerializerMethodField()
+
+    class Meta:
+        model = D2Daemon
+        fields = (
+            "id",
+            "url",
+            "display",
+            "name",
+            "description",
+            "ip_address",
+            "port",
+            "control_socket_path",
+            "ncr_protocol",
+            "ncr_format",
+            "domains_count",
+            "tags",
+            "custom_fields",
+            "created",
+            "last_updated",
+        )
+
+    def get_domains_count(self, obj):
+        return obj.domains.count()
+
+
+class DDNSDomainSerializer(NetBoxModelSerializer):
+    url = serializers.HyperlinkedIdentityField(view_name="plugins-api:netbox_dhcp_kea_plugin-api:ddnsdomain-detail")
+    d2_daemon = NestedD2DaemonSerializer(read_only=True)
+    tsig_key = NestedTSIGKeySerializer(read_only=True)
+    zone = serializers.SerializerMethodField()
+    is_reverse = serializers.BooleanField(read_only=True)
+
+    class Meta:
+        model = DDNSDomain
+        fields = (
+            "id",
+            "url",
+            "display",
+            "d2_daemon",
+            "zone",
+            "tsig_key",
+            "is_reverse",
+            "tags",
+            "custom_fields",
+            "created",
+            "last_updated",
+        )
+
+    def get_zone(self, obj):
+        if obj.zone_id is None:
+            return None
+        return {"id": obj.zone_id, "name": obj.zone.name}
+
+
+class DDNSPolicySerializer(NetBoxModelSerializer):
+    url = serializers.HyperlinkedIdentityField(view_name="plugins-api:netbox_dhcp_kea_plugin-api:ddnspolicy-detail")
+
+    class Meta:
+        model = DDNSPolicy
+        fields = (
+            "id",
+            "url",
+            "display",
+            "name",
+            "description",
+            "ddns_send_updates",
+            "ddns_override_no_update",
+            "ddns_override_client_update",
+            "ddns_replace_client_name",
+            "ddns_generated_prefix",
+            "ddns_qualifying_suffix",
+            "hostname_char_set",
+            "hostname_char_replacement",
+            "ddns_update_on_renew",
+            "ddns_conflict_resolution_mode",
+            "ddns_ttl_percent",
+            "ddns_ttl",
+            "ddns_ttl_min",
+            "ddns_ttl_max",
+            "tags",
+            "custom_fields",
+            "created",
+            "last_updated",
+        )

--- a/netbox_dhcp_kea_plugin/api/serializers.py
+++ b/netbox_dhcp_kea_plugin/api/serializers.py
@@ -644,6 +644,7 @@ class D2DaemonSerializer(NetBoxModelSerializer):
             "display",
             "name",
             "description",
+            "listener_mode",
             "ip_address",
             "port",
             "control_socket_path",

--- a/netbox_dhcp_kea_plugin/api/urls.py
+++ b/netbox_dhcp_kea_plugin/api/urls.py
@@ -20,6 +20,11 @@ router.register("ha-relationships", views.DHCPHARelationshipViewSet)
 if get_plugin_config("netbox_dhcp_kea_plugin", "enable_stork"):
     router.register("stork-servers", views.StorkServerViewSet)
     router.register("stork-agent-groups", views.StorkAgentGroupViewSet)
+if get_plugin_config("netbox_dhcp_kea_plugin", "enable_ddns"):
+    router.register("tsig-keys", views.TSIGKeyViewSet)
+    router.register("d2-daemons", views.D2DaemonViewSet)
+    router.register("ddns-domains", views.DDNSDomainViewSet)
+    router.register("ddns-policies", views.DDNSPolicyViewSet)
 
 urlpatterns = router.urls + [
     # Lookup DHCP relay config by prefix

--- a/netbox_dhcp_kea_plugin/api/views.py
+++ b/netbox_dhcp_kea_plugin/api/views.py
@@ -20,6 +20,9 @@ class PlainTextRenderer(BaseRenderer):
 from .. import filtersets
 from ..models import (
     ClientClass,
+    D2Daemon,
+    DDNSDomain,
+    DDNSPolicy,
     DHCPHARelationship,
     DHCPServer,
     Hook,
@@ -30,10 +33,14 @@ from ..models import (
     StorkServer,
     Subnet,
     SubnetPool,
+    TSIGKey,
     VendorOptionSpace,
 )
 from .serializers import (
     ClientClassSerializer,
+    D2DaemonSerializer,
+    DDNSDomainSerializer,
+    DDNSPolicySerializer,
     DHCPHARelationshipSerializer,
     DHCPServerSerializer,
     HookGroupSerializer,
@@ -44,6 +51,7 @@ from .serializers import (
     StorkServerSerializer,
     SubnetPoolSerializer,
     SubnetSerializer,
+    TSIGKeySerializer,
     VendorOptionSpaceSerializer,
 )
 
@@ -312,3 +320,38 @@ class StorkAgentGroupViewSet(NetBoxModelViewSet):
 
         env_content = agent_group.to_env_content(server=server)
         return Response(env_content)
+
+
+# ----- DDNS ViewSets -----
+
+
+class TSIGKeyViewSet(NetBoxModelViewSet):
+    queryset = TSIGKey.objects.all()
+    serializer_class = TSIGKeySerializer
+    filterset_class = filtersets.TSIGKeyFilterSet
+
+
+class D2DaemonViewSet(NetBoxModelViewSet):
+    queryset = D2Daemon.objects.select_related("ip_address").prefetch_related("domains")
+    serializer_class = D2DaemonSerializer
+    filterset_class = filtersets.D2DaemonFilterSet
+
+    @action(detail=True, methods=["get"], url_path="kea-config")
+    def kea_config(self, request, pk=None):
+        """
+        Return the complete kea-dhcp-ddns configuration for this D2 daemon.
+        """
+        daemon = self.get_object()
+        return Response(daemon.to_kea_dict())
+
+
+class DDNSDomainViewSet(NetBoxModelViewSet):
+    queryset = DDNSDomain.objects.select_related("d2_daemon", "tsig_key", "zone")
+    serializer_class = DDNSDomainSerializer
+    filterset_class = filtersets.DDNSDomainFilterSet
+
+
+class DDNSPolicyViewSet(NetBoxModelViewSet):
+    queryset = DDNSPolicy.objects.prefetch_related("servers", "subnets", "client_classes")
+    serializer_class = DDNSPolicySerializer
+    filterset_class = filtersets.DDNSPolicyFilterSet

--- a/netbox_dhcp_kea_plugin/filtersets.py
+++ b/netbox_dhcp_kea_plugin/filtersets.py
@@ -7,6 +7,9 @@ from netbox.plugins.utils import get_plugin_config
 
 from .models import (
     ClientClass,
+    D2Daemon,
+    DDNSDomain,
+    DDNSPolicy,
     DHCPHARelationship,
     DHCPServer,
     Hook,
@@ -17,6 +20,7 @@ from .models import (
     StorkServer,
     Subnet,
     SubnetPool,
+    TSIGKey,
     VendorOptionSpace,
 )
 
@@ -37,12 +41,18 @@ class DHCPServerFilterSet(NetBoxModelFilterSet):
     stork_agent_group = django_filters.ModelChoiceFilter(
         queryset=StorkAgentGroup.objects.all(), label="Stork Agent Group"
     )
+    d2_daemon = django_filters.ModelChoiceFilter(queryset=D2Daemon.objects.all(), label="D2 Daemon")
+    ddns_policy = django_filters.ModelChoiceFilter(queryset=DDNSPolicy.objects.all(), label="DDNS Policy")
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         if not get_plugin_config("netbox_dhcp_kea_plugin", "enable_stork"):
             if "stork_agent_group" in self.filters:
                 del self.filters["stork_agent_group"]
+        if not get_plugin_config("netbox_dhcp_kea_plugin", "enable_ddns"):
+            for fname in ("d2_daemon", "ddns_policy"):
+                if fname in self.filters:
+                    del self.filters[fname]
 
     class Meta:
         model = DHCPServer
@@ -55,6 +65,8 @@ class DHCPServerFilterSet(NetBoxModelFilterSet):
             "ha_auto_failover",
             "stork_agent_group",
             "ctrl_socket_type",
+            "d2_daemon",
+            "ddns_policy",
         ]
 
     def search(self, queryset, name, value):
@@ -313,6 +325,80 @@ class StorkAgentGroupFilterSet(NetBoxModelFilterSet):
     class Meta:
         model = StorkAgentGroup
         fields = ["id", "name", "stork_server", "operating_mode", "server"]
+
+    def search(self, queryset, name, value):
+        if not value.strip():
+            return queryset
+        return queryset.filter(Q(name__icontains=value) | Q(description__icontains=value))
+
+
+# --- DDNS FilterSets ---
+
+
+class TSIGKeyFilterSet(NetBoxModelFilterSet):
+    class Meta:
+        model = TSIGKey
+        fields = ["id", "name", "algorithm", "secret_backend"]
+
+    def search(self, queryset, name, value):
+        if not value.strip():
+            return queryset
+        return queryset.filter(Q(name__icontains=value) | Q(description__icontains=value))
+
+
+class D2DaemonFilterSet(NetBoxModelFilterSet):
+    ncr_protocol = django_filters.ChoiceFilter(choices=[("UDP", "UDP"), ("TCP", "TCP")])
+
+    class Meta:
+        model = D2Daemon
+        fields = ["id", "name", "ip_address", "port", "ncr_protocol", "ncr_format"]
+
+    def search(self, queryset, name, value):
+        if not value.strip():
+            return queryset
+        return queryset.filter(Q(name__icontains=value) | Q(description__icontains=value))
+
+
+class DDNSDomainFilterSet(NetBoxModelFilterSet):
+    d2_daemon = django_filters.ModelChoiceFilter(queryset=D2Daemon.objects.all())
+    tsig_key = django_filters.ModelChoiceFilter(queryset=TSIGKey.objects.all())
+
+    class Meta:
+        model = DDNSDomain
+        fields = ["id", "d2_daemon", "zone", "tsig_key"]
+
+    def search(self, queryset, name, value):
+        if not value.strip():
+            return queryset
+        return queryset.filter(Q(d2_daemon__name__icontains=value))
+
+
+class DDNSPolicyFilterSet(NetBoxModelFilterSet):
+    server = django_filters.ModelChoiceFilter(
+        field_name="servers",
+        queryset=DHCPServer.objects.all(),
+        label="DHCP Server",
+    )
+    subnet = django_filters.ModelChoiceFilter(
+        field_name="subnets",
+        queryset=Subnet.objects.all(),
+    )
+    client_class = django_filters.ModelChoiceFilter(
+        field_name="client_classes",
+        queryset=ClientClass.objects.all(),
+    )
+
+    class Meta:
+        model = DDNSPolicy
+        fields = [
+            "id",
+            "name",
+            "ddns_send_updates",
+            "ddns_conflict_resolution_mode",
+            "server",
+            "subnet",
+            "client_class",
+        ]
 
     def search(self, queryset, name, value):
         if not value.strip():

--- a/netbox_dhcp_kea_plugin/forms.py
+++ b/netbox_dhcp_kea_plugin/forms.py
@@ -2193,12 +2193,17 @@ class TSIGKeyImportForm(NetBoxModelImportForm):
 class D2DaemonForm(NetBoxModelForm):
     ip_address = DynamicModelChoiceField(
         queryset=IPAddress.objects.all(),
-        help_text="Listener IP for NameChangeRequests from kea-dhcp4/6",
+        required=False,
+        help_text="Listener IP for NameChangeRequests from kea-dhcp4/6 (only when mode is 'remote')",
     )
 
     fieldsets = (
         FieldSet("name", "description", "tags", name="General"),
-        FieldSet(InlineFields("ip_address", "port", label="Listener"), name="NCR Listener"),
+        FieldSet(
+            "listener_mode",
+            InlineFields("ip_address", "port", label="Listener"),
+            name="NCR Listener",
+        ),
         FieldSet("ncr_protocol", "ncr_format", name="NCR Transport"),
         FieldSet("control_socket_path", name="Control Socket"),
     )
@@ -2208,6 +2213,7 @@ class D2DaemonForm(NetBoxModelForm):
         fields = (
             "name",
             "description",
+            "listener_mode",
             "ip_address",
             "port",
             "ncr_protocol",
@@ -2215,6 +2221,17 @@ class D2DaemonForm(NetBoxModelForm):
             "control_socket_path",
             "tags",
         )
+        widgets = {
+            "listener_mode": HTMXSelect(),
+        }
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        # Hide ip_address and port when the daemon is in local-listener mode —
+        # each peer runs its own D2 on 127.0.0.1 with the model default port.
+        if get_field_value(self, "listener_mode") == D2Daemon.LISTENER_MODE_LOCAL:
+            for fname in ("ip_address", "port"):
+                self.fields.pop(fname, None)
 
 
 class D2DaemonFilterForm(NetBoxModelFilterSetForm):
@@ -2231,6 +2248,7 @@ class D2DaemonImportForm(NetBoxModelImportForm):
     ip_address = CSVModelChoiceField(
         queryset=IPAddress.objects.all(),
         to_field_name="address",
+        required=False,
     )
 
     class Meta:
@@ -2238,6 +2256,7 @@ class D2DaemonImportForm(NetBoxModelImportForm):
         fields = (
             "name",
             "description",
+            "listener_mode",
             "ip_address",
             "port",
             "ncr_protocol",

--- a/netbox_dhcp_kea_plugin/forms.py
+++ b/netbox_dhcp_kea_plugin/forms.py
@@ -2264,6 +2264,7 @@ class DDNSDomainForm(NetBoxModelForm):
     tsig_key = DynamicModelChoiceField(
         queryset=TSIGKey.objects.all(),
         required=False,
+        quick_add=True,
         help_text="TSIG key for authenticating updates to this zone (optional)",
     )
 

--- a/netbox_dhcp_kea_plugin/forms.py
+++ b/netbox_dhcp_kea_plugin/forms.py
@@ -5,6 +5,7 @@ from django.core.exceptions import ValidationError
 from django.utils.safestring import mark_safe
 from ipam.models import IPAddress, IPRange, Prefix, ServiceTemplate
 from netbox.forms import (
+    NetBoxModelBulkEditForm,
     NetBoxModelFilterSetForm,
     NetBoxModelForm,
     NetBoxModelImportForm,
@@ -2253,14 +2254,6 @@ except ImportError:  # netbox_dns is optional unless enable_ddns=True
 
 class DDNSDomainForm(NetBoxModelForm):
     d2_daemon = DynamicModelChoiceField(queryset=D2Daemon.objects.all())
-    if _DNSZone is not None:
-        zone = DynamicModelChoiceField(
-            queryset=_DNSZone.objects.all(),
-            help_text=(
-                "Forward or reverse zone managed by this D2 daemon. "
-                "Authoritative DNS servers are taken from the zone's nameservers."
-            ),
-        )
     tsig_key = DynamicModelChoiceField(
         queryset=TSIGKey.objects.all(),
         required=False,
@@ -2282,6 +2275,86 @@ class DDNSDomainForm(NetBoxModelForm):
                 "DDNSDomainForm requires netbox-plugin-dns to be installed."
             )
         super().__init__(*args, **kwargs)
+        if self.instance.pk is None:
+            # Create mode: pick any number of zones (forward and/or reverse).
+            # One DDNSDomain row will be created per selected zone; direction
+            # is derived from each zone's name at config-emission time.
+            self.fields["zone"] = DynamicModelMultipleChoiceField(
+                queryset=_DNSZone.objects.all(),
+                label="Zones",
+                help_text=(
+                    "Select one or more forward and/or reverse zones managed "
+                    "by this D2 daemon. One DDNS Domain row is created per "
+                    "selected zone."
+                ),
+            )
+        else:
+            # Edit mode: a row binds exactly one zone.
+            self.fields["zone"] = DynamicModelChoiceField(
+                queryset=_DNSZone.objects.all(),
+                help_text=(
+                    "Forward or reverse zone managed by this D2 daemon. "
+                    "Authoritative DNS servers are taken from the zone's "
+                    "nameservers."
+                ),
+            )
+
+    def _post_clean(self):
+        # In create mode, ``zone`` is a queryset of multiple Zones — Django's
+        # ModelForm._post_clean() would try to assign it to the single-FK
+        # ``instance.zone`` and ValueError. Temporarily swap in the first
+        # selected zone so model-level validation has a real instance, then
+        # restore the queryset for our save() override.
+        zones = self.cleaned_data.get("zone")
+        if (
+            self.instance.pk is None
+            and zones is not None
+            and not isinstance(zones, _DNSZone)
+        ):
+            zone_list = list(zones)
+            if zone_list:
+                self.cleaned_data["zone"] = zone_list[0]
+                try:
+                    super()._post_clean()
+                finally:
+                    self.cleaned_data["zone"] = zone_list
+                return
+        super()._post_clean()
+
+    def save(self, commit=True):
+        # Edit path: standard single-instance save.
+        if self.instance.pk:
+            return super().save(commit=commit)
+
+        zones_or_one = self.cleaned_data.get("zone")
+        zones = (
+            [zones_or_one]
+            if isinstance(zones_or_one, _DNSZone)
+            else list(zones_or_one or [])
+        )
+        d2_daemon = self.cleaned_data["d2_daemon"]
+        tsig_key = self.cleaned_data.get("tsig_key")
+        tags = self.cleaned_data.get("tags") or []
+
+        created = []
+        for z in zones:
+            obj, was_created = DDNSDomain.objects.get_or_create(
+                d2_daemon=d2_daemon,
+                zone=z,
+                defaults={"tsig_key": tsig_key},
+            )
+            new_tsig_pk = tsig_key.pk if tsig_key else None
+            if not was_created and obj.tsig_key_id != new_tsig_pk:
+                obj.tsig_key = tsig_key
+                obj.save()
+            if tags:
+                obj.tags.set(tags)
+            created.append(obj)
+
+        # Point self.instance at one of the new rows so the view's success
+        # message and redirect have something to chew on.
+        self.instance = created[0] if created else self.instance
+        return self.instance
 
 
 class DDNSDomainFilterForm(NetBoxModelFilterSetForm):
@@ -2301,6 +2374,15 @@ class DDNSDomainImportForm(NetBoxModelImportForm):
     class Meta:
         model = DDNSDomain
         fields = ("d2_daemon", "zone", "tsig_key")
+
+
+class DDNSDomainBulkEditForm(NetBoxModelBulkEditForm):
+    d2_daemon = DynamicModelChoiceField(queryset=D2Daemon.objects.all(), required=False)
+    tsig_key = DynamicModelChoiceField(queryset=TSIGKey.objects.all(), required=False)
+
+    model = DDNSDomain
+    fieldsets = (FieldSet("d2_daemon", "tsig_key"),)
+    nullable_fields = ("tsig_key",)
 
 
 class DDNSPolicyForm(NetBoxModelForm):

--- a/netbox_dhcp_kea_plugin/forms.py
+++ b/netbox_dhcp_kea_plugin/forms.py
@@ -1649,6 +1649,14 @@ class DHCPHARelationshipForm(NetBoxModelForm):
             "Shared Kea D2 daemon for all member servers. When set, each member's standalone D2 daemon is ignored."
         ),
     )
+    ddns_policy = DynamicModelChoiceField(
+        queryset=DDNSPolicy.objects.all(),
+        required=False,
+        label="DDNS policy",
+        help_text=(
+            "Shared DDNS policy for all member servers. When set, each member's standalone DDNS policy is ignored."
+        ),
+    )
 
     fieldsets = (
         FieldSet("name", "mode", "description", "tags", name="General"),
@@ -1667,7 +1675,7 @@ class DHCPHARelationshipForm(NetBoxModelForm):
         FieldSet(
             "ddns_enable_updates",
             "d2_daemon",
-            InlineFields("ddns_sender_ip", "ddns_sender_port", label="Sender"),
+            "ddns_policy",
             name="DDNS",
         ),
     )
@@ -1689,20 +1697,14 @@ class DHCPHARelationshipForm(NetBoxModelForm):
             "description",
             "d2_daemon",
             "ddns_enable_updates",
-            "ddns_sender_ip",
-            "ddns_sender_port",
+            "ddns_policy",
             "tags",
         )
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         if not get_plugin_config("netbox_dhcp_kea_plugin", "enable_ddns"):
-            for fname in (
-                "d2_daemon",
-                "ddns_enable_updates",
-                "ddns_sender_ip",
-                "ddns_sender_port",
-            ):
+            for fname in ("d2_daemon", "ddns_enable_updates", "ddns_policy"):
                 if fname in self.fields:
                     del self.fields[fname]
 

--- a/netbox_dhcp_kea_plugin/forms.py
+++ b/netbox_dhcp_kea_plugin/forms.py
@@ -895,8 +895,7 @@ class DHCPServerForm(NetBoxModelForm):
         required=False,
         label="D2 daemon",
         help_text=(
-            "Kea D2 daemon to send NCRs to. Ignored when the server is in an "
-            "HA relationship that itself has a D2 daemon set."
+            "Kea D2 daemon to send NCRs to. Ignored when the server is in an HA relationship with D2 daemon set."
         ),
     )
     ddns_policy = DynamicModelChoiceField(
@@ -943,10 +942,10 @@ class DHCPServerForm(NetBoxModelForm):
             ),
             FieldSet("stork_agent_group", name="Stork Monitoring"),
             FieldSet(
-                "d2_daemon",
                 "ddns_enable_updates",
-                InlineFields("ddns_sender_ip", "ddns_sender_port", label="Sender"),
+                "d2_daemon",
                 "ddns_policy",
+                InlineFields("ddns_sender_ip", "ddns_sender_port", label="Sender"),
                 name="DDNS",
             ),
             FieldSet(
@@ -1647,8 +1646,7 @@ class DHCPHARelationshipForm(NetBoxModelForm):
         required=False,
         label="D2 daemon",
         help_text=(
-            "Shared Kea D2 daemon for all member servers. When set, each member's "
-            "standalone D2 daemon is ignored."
+            "Shared Kea D2 daemon for all member servers. When set, each member's standalone D2 daemon is ignored."
         ),
     )
 
@@ -1667,8 +1665,8 @@ class DHCPHARelationshipForm(NetBoxModelForm):
             name="Multi-Threading",
         ),
         FieldSet(
-            "d2_daemon",
             "ddns_enable_updates",
+            "d2_daemon",
             InlineFields("ddns_sender_ip", "ddns_sender_port", label="Sender"),
             name="DDNS",
         ),
@@ -2261,9 +2259,7 @@ class DDNSDomainForm(NetBoxModelForm):
         help_text="TSIG key for authenticating updates to this zone (optional)",
     )
 
-    fieldsets = (
-        FieldSet("d2_daemon", "zone", "tsig_key", "tags", name="General"),
-    )
+    fieldsets = (FieldSet("d2_daemon", "zone", "tsig_key", "tags", name="General"),)
 
     class Meta:
         model = DDNSDomain
@@ -2271,9 +2267,7 @@ class DDNSDomainForm(NetBoxModelForm):
 
     def __init__(self, *args, **kwargs):
         if _DNSZone is None:
-            raise RuntimeError(
-                "DDNSDomainForm requires netbox-plugin-dns to be installed."
-            )
+            raise RuntimeError("DDNSDomainForm requires netbox-plugin-dns to be installed.")
         super().__init__(*args, **kwargs)
         if self.instance.pk is None:
             # Create mode: pick any number of zones (forward and/or reverse).
@@ -2306,11 +2300,7 @@ class DDNSDomainForm(NetBoxModelForm):
         # selected zone so model-level validation has a real instance, then
         # restore the queryset for our save() override.
         zones = self.cleaned_data.get("zone")
-        if (
-            self.instance.pk is None
-            and zones is not None
-            and not isinstance(zones, _DNSZone)
-        ):
+        if self.instance.pk is None and zones is not None and not isinstance(zones, _DNSZone):
             zone_list = list(zones)
             if zone_list:
                 self.cleaned_data["zone"] = zone_list[0]
@@ -2327,11 +2317,7 @@ class DDNSDomainForm(NetBoxModelForm):
             return super().save(commit=commit)
 
         zones_or_one = self.cleaned_data.get("zone")
-        zones = (
-            [zones_or_one]
-            if isinstance(zones_or_one, _DNSZone)
-            else list(zones_or_one or [])
-        )
+        zones = [zones_or_one] if isinstance(zones_or_one, _DNSZone) else list(zones_or_one or [])
         d2_daemon = self.cleaned_data["d2_daemon"]
         tsig_key = self.cleaned_data.get("tsig_key")
         tags = self.cleaned_data.get("tags") or []

--- a/netbox_dhcp_kea_plugin/forms.py
+++ b/netbox_dhcp_kea_plugin/forms.py
@@ -2227,6 +2227,14 @@ class D2DaemonForm(NetBoxModelForm):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
+        # Default the control socket path from plugin config when creating
+        # a new D2Daemon (existing rows keep whatever they were saved with).
+        # Set form.initial (not field.initial) — ModelForm populates initial
+        # from the empty model instance and that wins over field.initial.
+        if not self.instance.pk and not self.initial.get("control_socket_path"):
+            self.initial["control_socket_path"] = get_plugin_config(
+                "netbox_dhcp_kea_plugin", "d2_default_control_socket_path"
+            )
         # Hide ip_address and port when the daemon is in local-listener mode —
         # each peer runs its own D2 on 127.0.0.1 with the model default port.
         if get_field_value(self, "listener_mode") == D2Daemon.LISTENER_MODE_LOCAL:

--- a/netbox_dhcp_kea_plugin/forms.py
+++ b/netbox_dhcp_kea_plugin/forms.py
@@ -22,6 +22,9 @@ from utilities.forms.widgets import HTMXSelect
 
 from .models import (
     ClientClass,
+    D2Daemon,
+    DDNSDomain,
+    DDNSPolicy,
     DHCPHARelationship,
     DHCPServer,
     Hook,
@@ -32,6 +35,7 @@ from .models import (
     StorkServer,
     Subnet,
     SubnetPool,
+    TSIGKey,
     VendorOptionSpace,
 )
 
@@ -885,6 +889,20 @@ class DHCPServerForm(NetBoxModelForm):
         required=False,
         help_text="Stork agent group configuration for this DHCP server",
     )
+    d2_daemon = DynamicModelChoiceField(
+        queryset=D2Daemon.objects.all(),
+        required=False,
+        label="D2 daemon",
+        help_text=(
+            "Kea D2 daemon to send NCRs to. Ignored when the server is in an "
+            "HA relationship that itself has a D2 daemon set."
+        ),
+    )
+    ddns_policy = DynamicModelChoiceField(
+        queryset=DDNSPolicy.objects.all(),
+        required=False,
+        help_text="Server-level DDNS policy (ddns-* tunables)",
+    )
 
     @property
     def fieldsets(self):
@@ -924,6 +942,13 @@ class DHCPServerForm(NetBoxModelForm):
             ),
             FieldSet("stork_agent_group", name="Stork Monitoring"),
             FieldSet(
+                "d2_daemon",
+                "ddns_enable_updates",
+                InlineFields("ddns_sender_ip", "ddns_sender_port", label="Sender"),
+                "ddns_policy",
+                name="DDNS",
+            ),
+            FieldSet(
                 "ha_relationship",
                 "ha_role",
                 InlineFields("ha_address", "ha_port", label="HA Peer"),
@@ -949,6 +974,11 @@ class DHCPServerForm(NetBoxModelForm):
             "reservations_in_subnet",
             "reservations_out_of_pool",
             "stork_agent_group",
+            "d2_daemon",
+            "ddns_enable_updates",
+            "ddns_sender_ip",
+            "ddns_sender_port",
+            "ddns_policy",
             "ctrl_socket_type",
             "ctrl_socket_http_address",
             "ctrl_socket_http_port",
@@ -975,6 +1005,18 @@ class DHCPServerForm(NetBoxModelForm):
         if not get_plugin_config("netbox_dhcp_kea_plugin", "enable_stork"):
             if "stork_agent_group" in self.fields:
                 del self.fields["stork_agent_group"]
+
+        # Hide DDNS fields when DDNS is disabled in plugin settings
+        if not get_plugin_config("netbox_dhcp_kea_plugin", "enable_ddns"):
+            for fname in (
+                "d2_daemon",
+                "ddns_enable_updates",
+                "ddns_sender_ip",
+                "ddns_sender_port",
+                "ddns_policy",
+            ):
+                if fname in self.fields:
+                    del self.fields[fname]
 
         # Determine the selected control socket type
         ctrl_socket_type = get_field_value(self, "ctrl_socket_type")
@@ -1060,6 +1102,11 @@ class ClientClassForm(NetBoxModelForm):
         required=False,
         help_text="Option data to send to clients matching this class",
     )
+    ddns_policy = DynamicModelChoiceField(
+        queryset=DDNSPolicy.objects.all(),
+        required=False,
+        help_text="Class-level DDNS policy overrides (ddns-* tunables)",
+    )
 
     class Meta:
         model = ClientClass
@@ -1073,6 +1120,7 @@ class ClientClassForm(NetBoxModelForm):
             "next_server",
             "server_hostname",
             "boot_file_name",
+            "ddns_policy",
             "tags",
         )
 
@@ -1081,6 +1129,7 @@ class ClientClassForm(NetBoxModelForm):
         FieldSet("servers", "option_data", name="Assignments"),
         FieldSet("only_in_additional_list", name="Evaluation"),
         FieldSet("next_server", "server_hostname", "boot_file_name", name="Boot Options"),
+        FieldSet("ddns_policy", name="DDNS"),
     )
 
     def __init__(self, *args, **kwargs):
@@ -1096,6 +1145,11 @@ class ClientClassForm(NetBoxModelForm):
         self._redirected_to_primary = False
         self._redirected_server_names = []
         self._primary_server_names = []
+
+        # Hide DDNS fields when DDNS is disabled in plugin settings
+        if not get_plugin_config("netbox_dhcp_kea_plugin", "enable_ddns"):
+            if "ddns_policy" in self.fields:
+                del self.fields["ddns_policy"]
 
     def clean_option_data(self):
         """Validate that no two option data entries have the same space and code."""
@@ -1192,6 +1246,11 @@ class SubnetForm(NetBoxModelForm):
         label="Reservations Out-of-Pool",
         help_text="Exclude reserved addresses from dynamic pool allocation. Leave blank to inherit from server.",
     )
+    ddns_policy = DynamicModelChoiceField(
+        queryset=DDNSPolicy.objects.all(),
+        required=False,
+        help_text="Subnet-level DDNS policy overrides (ddns-* tunables)",
+    )
 
     fieldsets = (
         FieldSet("prefix", "server", name="Prefix Assignment"),
@@ -1211,6 +1270,7 @@ class SubnetForm(NetBoxModelForm):
             "reservations_only",
             name="Reservations",
         ),
+        FieldSet("ddns_policy", name="DDNS"),
     )
 
     class Meta:
@@ -1228,6 +1288,7 @@ class SubnetForm(NetBoxModelForm):
             "reservations_in_subnet",
             "reservations_out_of_pool",
             "reservations_only",
+            "ddns_policy",
             "tags",
         )
 
@@ -1237,6 +1298,11 @@ class SubnetForm(NetBoxModelForm):
         inherit_label = [("unknown", "Inherit from Server"), ("true", "Yes"), ("false", "No")]
         for field_name in ("reservations_global", "reservations_in_subnet", "reservations_out_of_pool"):
             self.fields[field_name].widget.choices = inherit_label
+
+        # Hide DDNS fields when DDNS is disabled in plugin settings
+        if not get_plugin_config("netbox_dhcp_kea_plugin", "enable_ddns"):
+            if "ddns_policy" in self.fields:
+                del self.fields["ddns_policy"]
 
         # Track if server was redirected to primary (for messaging)
         self._redirected_to_primary = False
@@ -1575,6 +1641,16 @@ class SubnetPoolFilterForm(NetBoxModelFilterSetForm):
 
 # DHCPHARelationship Forms
 class DHCPHARelationshipForm(NetBoxModelForm):
+    d2_daemon = DynamicModelChoiceField(
+        queryset=D2Daemon.objects.all(),
+        required=False,
+        label="D2 daemon",
+        help_text=(
+            "Shared Kea D2 daemon for all member servers. When set, each member's "
+            "standalone D2 daemon is ignored."
+        ),
+    )
+
     fieldsets = (
         FieldSet("name", "mode", "description", "tags", name="General"),
         FieldSet(
@@ -1588,6 +1664,12 @@ class DHCPHARelationshipForm(NetBoxModelForm):
             "http_dedicated_listener",
             InlineFields("http_listener_threads", "http_client_threads", label="Thread Counts"),
             name="Multi-Threading",
+        ),
+        FieldSet(
+            "d2_daemon",
+            "ddns_enable_updates",
+            InlineFields("ddns_sender_ip", "ddns_sender_port", label="Sender"),
+            name="DDNS",
         ),
     )
 
@@ -1606,8 +1688,24 @@ class DHCPHARelationshipForm(NetBoxModelForm):
             "http_listener_threads",
             "http_client_threads",
             "description",
+            "d2_daemon",
+            "ddns_enable_updates",
+            "ddns_sender_ip",
+            "ddns_sender_port",
             "tags",
         )
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        if not get_plugin_config("netbox_dhcp_kea_plugin", "enable_ddns"):
+            for fname in (
+                "d2_daemon",
+                "ddns_enable_updates",
+                "ddns_sender_ip",
+                "ddns_sender_port",
+            ):
+                if fname in self.fields:
+                    del self.fields[fname]
 
 
 class DHCPHARelationshipFilterForm(NetBoxModelFilterSetForm):
@@ -2014,4 +2112,289 @@ class StorkAgentGroupImportForm(NetBoxModelImportForm):
             "prometheus_per_subnet_stats",
             "skip_tls_cert_verification",
             "log_level",
+        )
+
+
+# --- DDNS Forms ---
+
+
+class TSIGKeyForm(NetBoxModelForm):
+    fieldsets = (
+        FieldSet("name", "description", "tags", name="General"),
+        FieldSet("algorithm", "digest_bits", name="Algorithm"),
+        FieldSet("secret_backend", "secret_plaintext", "secret_ref", name="Secret"),
+    )
+
+    class Meta:
+        model = TSIGKey
+        fields = (
+            "name",
+            "description",
+            "algorithm",
+            "digest_bits",
+            "secret_backend",
+            "secret_plaintext",
+            "secret_ref",
+            "tags",
+        )
+        widgets = {
+            "secret_backend": HTMXSelect(),
+            "secret_plaintext": forms.PasswordInput(render_value=True),
+        }
+
+    def __init__(self, *args, **kwargs):
+        request = kwargs.pop("request", None)
+        super().__init__(*args, **kwargs)
+
+        # Show only the secret field relevant to the selected backend.
+        secret_backend = get_field_value(self, "secret_backend")
+        if secret_backend != "plaintext":
+            del self.fields["secret_plaintext"]
+        if secret_backend != "vault":
+            del self.fields["secret_ref"]
+
+        # Hide the plaintext secret from users who lack the reveal perm when
+        # editing. New objects always show the field (you need to set it
+        # somehow, and creating the row implies write).
+        if self.instance.pk and request is not None:
+            if not request.user.has_perm("netbox_dhcp_kea_plugin.view_secret_tsigkey"):
+                if "secret_plaintext" in self.fields:
+                    del self.fields["secret_plaintext"]
+
+
+class TSIGKeyFilterForm(NetBoxModelFilterSetForm):
+    model = TSIGKey
+    name = forms.CharField(required=False)
+    algorithm = forms.ChoiceField(
+        choices=[("", "---------")] + list(TSIGKey._meta.get_field("algorithm").choices or []),
+        required=False,
+    )
+    secret_backend = forms.ChoiceField(
+        choices=[("", "---------")] + list(TSIGKey._meta.get_field("secret_backend").choices or []),
+        required=False,
+    )
+
+
+class TSIGKeyImportForm(NetBoxModelImportForm):
+    class Meta:
+        model = TSIGKey
+        fields = (
+            "name",
+            "description",
+            "algorithm",
+            "digest_bits",
+            "secret_backend",
+            "secret_plaintext",
+            "secret_ref",
+        )
+
+
+class D2DaemonForm(NetBoxModelForm):
+    ip_address = DynamicModelChoiceField(
+        queryset=IPAddress.objects.all(),
+        help_text="Listener IP for NameChangeRequests from kea-dhcp4/6",
+    )
+
+    fieldsets = (
+        FieldSet("name", "description", "tags", name="General"),
+        FieldSet(InlineFields("ip_address", "port", label="Listener"), name="NCR Listener"),
+        FieldSet("ncr_protocol", "ncr_format", name="NCR Transport"),
+        FieldSet("control_socket_path", name="Control Socket"),
+    )
+
+    class Meta:
+        model = D2Daemon
+        fields = (
+            "name",
+            "description",
+            "ip_address",
+            "port",
+            "ncr_protocol",
+            "ncr_format",
+            "control_socket_path",
+            "tags",
+        )
+
+
+class D2DaemonFilterForm(NetBoxModelFilterSetForm):
+    model = D2Daemon
+    name = forms.CharField(required=False)
+    ip_address = DynamicModelChoiceField(queryset=IPAddress.objects.all(), required=False)
+    ncr_protocol = forms.ChoiceField(
+        choices=[("", "---------"), ("UDP", "UDP"), ("TCP", "TCP")],
+        required=False,
+    )
+
+
+class D2DaemonImportForm(NetBoxModelImportForm):
+    ip_address = CSVModelChoiceField(
+        queryset=IPAddress.objects.all(),
+        to_field_name="address",
+    )
+
+    class Meta:
+        model = D2Daemon
+        fields = (
+            "name",
+            "description",
+            "ip_address",
+            "port",
+            "ncr_protocol",
+            "ncr_format",
+            "control_socket_path",
+        )
+
+
+try:
+    from netbox_dns.models import Zone as _DNSZone
+except ImportError:  # netbox_dns is optional unless enable_ddns=True
+    _DNSZone = None
+
+
+class DDNSDomainForm(NetBoxModelForm):
+    d2_daemon = DynamicModelChoiceField(queryset=D2Daemon.objects.all())
+    if _DNSZone is not None:
+        zone = DynamicModelChoiceField(
+            queryset=_DNSZone.objects.all(),
+            help_text=(
+                "Forward or reverse zone managed by this D2 daemon. "
+                "Authoritative DNS servers are taken from the zone's nameservers."
+            ),
+        )
+    tsig_key = DynamicModelChoiceField(
+        queryset=TSIGKey.objects.all(),
+        required=False,
+        help_text="TSIG key for authenticating updates to this zone (optional)",
+    )
+
+    fieldsets = (
+        FieldSet("d2_daemon", "zone", "tsig_key", "tags", name="General"),
+    )
+
+    class Meta:
+        model = DDNSDomain
+        fields = ("d2_daemon", "zone", "tsig_key", "tags")
+
+    def __init__(self, *args, **kwargs):
+        if _DNSZone is None:
+            raise RuntimeError(
+                "DDNSDomainForm requires netbox-plugin-dns to be installed."
+            )
+        super().__init__(*args, **kwargs)
+
+
+class DDNSDomainFilterForm(NetBoxModelFilterSetForm):
+    model = DDNSDomain
+    d2_daemon = DynamicModelChoiceField(queryset=D2Daemon.objects.all(), required=False)
+    tsig_key = DynamicModelChoiceField(queryset=TSIGKey.objects.all(), required=False)
+
+
+class DDNSDomainImportForm(NetBoxModelImportForm):
+    d2_daemon = CSVModelChoiceField(queryset=D2Daemon.objects.all(), to_field_name="name")
+    tsig_key = CSVModelChoiceField(
+        queryset=TSIGKey.objects.all(),
+        to_field_name="name",
+        required=False,
+    )
+
+    class Meta:
+        model = DDNSDomain
+        fields = ("d2_daemon", "zone", "tsig_key")
+
+
+class DDNSPolicyForm(NetBoxModelForm):
+    ddns_send_updates = forms.NullBooleanField(required=False)
+    ddns_override_no_update = forms.NullBooleanField(required=False)
+    ddns_override_client_update = forms.NullBooleanField(required=False)
+    ddns_update_on_renew = forms.NullBooleanField(required=False)
+
+    fieldsets = (
+        FieldSet("name", "description", "tags", name="General"),
+        FieldSet(
+            "ddns_send_updates",
+            "ddns_override_no_update",
+            "ddns_override_client_update",
+            "ddns_update_on_renew",
+            "ddns_replace_client_name",
+            name="Override Flags",
+        ),
+        FieldSet(
+            "ddns_generated_prefix",
+            "ddns_qualifying_suffix",
+            "hostname_char_set",
+            "hostname_char_replacement",
+            name="Hostname",
+        ),
+        FieldSet(
+            "ddns_conflict_resolution_mode",
+            name="Conflict Resolution",
+        ),
+        FieldSet(
+            "ddns_ttl_percent",
+            InlineFields("ddns_ttl", "ddns_ttl_min", "ddns_ttl_max", label="TTL (abs / min / max)"),
+            name="TTL",
+        ),
+    )
+
+    class Meta:
+        model = DDNSPolicy
+        fields = (
+            "name",
+            "description",
+            "ddns_send_updates",
+            "ddns_override_no_update",
+            "ddns_override_client_update",
+            "ddns_replace_client_name",
+            "ddns_generated_prefix",
+            "ddns_qualifying_suffix",
+            "hostname_char_set",
+            "hostname_char_replacement",
+            "ddns_update_on_renew",
+            "ddns_conflict_resolution_mode",
+            "ddns_ttl_percent",
+            "ddns_ttl",
+            "ddns_ttl_min",
+            "ddns_ttl_max",
+            "tags",
+        )
+
+
+class DDNSPolicyFilterForm(NetBoxModelFilterSetForm):
+    model = DDNSPolicy
+    name = forms.CharField(required=False)
+    server = DynamicModelChoiceField(
+        queryset=DHCPServer.objects.all(),
+        required=False,
+        label="DHCP Server",
+    )
+    subnet = DynamicModelChoiceField(
+        queryset=Subnet.objects.all(),
+        required=False,
+    )
+    client_class = DynamicModelChoiceField(
+        queryset=ClientClass.objects.all(),
+        required=False,
+    )
+
+
+class DDNSPolicyImportForm(NetBoxModelImportForm):
+    class Meta:
+        model = DDNSPolicy
+        fields = (
+            "name",
+            "description",
+            "ddns_send_updates",
+            "ddns_override_no_update",
+            "ddns_override_client_update",
+            "ddns_replace_client_name",
+            "ddns_generated_prefix",
+            "ddns_qualifying_suffix",
+            "hostname_char_set",
+            "hostname_char_replacement",
+            "ddns_update_on_renew",
+            "ddns_conflict_resolution_mode",
+            "ddns_ttl_percent",
+            "ddns_ttl",
+            "ddns_ttl_min",
+            "ddns_ttl_max",
         )

--- a/netbox_dhcp_kea_plugin/migrations/0006_ddns.py
+++ b/netbox_dhcp_kea_plugin/migrations/0006_ddns.py
@@ -76,6 +76,7 @@ class Migration(migrations.Migration):
                 ),
                 ("name", models.CharField(max_length=100, unique=True)),
                 ("description", models.CharField(blank=True, max_length=200)),
+                ("listener_mode", models.CharField(default="local", max_length=10)),
                 ("port", models.PositiveIntegerField(default=53001)),
                 (
                     "control_socket_path",
@@ -86,6 +87,8 @@ class Migration(migrations.Migration):
                 (
                     "ip_address",
                     models.ForeignKey(
+                        blank=True,
+                        null=True,
                         on_delete=django.db.models.deletion.PROTECT,
                         related_name="d2_daemons",
                         to="ipam.ipaddress",

--- a/netbox_dhcp_kea_plugin/migrations/0006_ddns.py
+++ b/netbox_dhcp_kea_plugin/migrations/0006_ddns.py
@@ -1,0 +1,317 @@
+import django.db.models.deletion
+import netbox.models.deletion
+import taggit.managers
+import utilities.json
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("extras", "0134_owner"),
+        ("ipam", "0086_gfk_indexes"),
+        ("netbox_dhcp_kea_plugin", "0005_optiondata_record_manual_fields"),
+        ("netbox_dns", "0001_squashed_netbox_dns_0_22"),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name="TSIGKey",
+            fields=[
+                (
+                    "id",
+                    models.BigAutoField(auto_created=True, primary_key=True, serialize=False),
+                ),
+                ("created", models.DateTimeField(auto_now_add=True, null=True)),
+                ("last_updated", models.DateTimeField(auto_now=True, null=True)),
+                (
+                    "custom_field_data",
+                    models.JSONField(
+                        blank=True,
+                        default=dict,
+                        encoder=utilities.json.CustomFieldJSONEncoder,
+                    ),
+                ),
+                ("name", models.CharField(max_length=255, unique=True)),
+                ("description", models.CharField(blank=True, max_length=200)),
+                ("algorithm", models.CharField(default="HMAC-SHA256", max_length=20)),
+                ("digest_bits", models.PositiveIntegerField(blank=True, null=True)),
+                ("secret_backend", models.CharField(default="plaintext", max_length=20)),
+                (
+                    "secret_plaintext",
+                    models.CharField(blank=True, default="", max_length=512),
+                ),
+                (
+                    "secret_ref",
+                    models.CharField(blank=True, default="", max_length=512),
+                ),
+                (
+                    "tags",
+                    taggit.managers.TaggableManager(through="extras.TaggedItem", to="extras.Tag"),
+                ),
+            ],
+            options={
+                "verbose_name": "TSIG Key",
+                "verbose_name_plural": "TSIG Keys",
+                "ordering": ("name",),
+                "permissions": [("view_secret_tsigkey", "Can view TSIG key plaintext secret")],
+            },
+            bases=(netbox.models.deletion.DeleteMixin, models.Model),
+        ),
+        migrations.CreateModel(
+            name="D2Daemon",
+            fields=[
+                (
+                    "id",
+                    models.BigAutoField(auto_created=True, primary_key=True, serialize=False),
+                ),
+                ("created", models.DateTimeField(auto_now_add=True, null=True)),
+                ("last_updated", models.DateTimeField(auto_now=True, null=True)),
+                (
+                    "custom_field_data",
+                    models.JSONField(
+                        blank=True,
+                        default=dict,
+                        encoder=utilities.json.CustomFieldJSONEncoder,
+                    ),
+                ),
+                ("name", models.CharField(max_length=100, unique=True)),
+                ("description", models.CharField(blank=True, max_length=200)),
+                ("port", models.PositiveIntegerField(default=53001)),
+                (
+                    "control_socket_path",
+                    models.CharField(blank=True, default="", max_length=512),
+                ),
+                ("ncr_protocol", models.CharField(default="UDP", max_length=3)),
+                ("ncr_format", models.CharField(default="JSON", max_length=4)),
+                (
+                    "ip_address",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.PROTECT,
+                        related_name="d2_daemons",
+                        to="ipam.ipaddress",
+                    ),
+                ),
+                (
+                    "tags",
+                    taggit.managers.TaggableManager(through="extras.TaggedItem", to="extras.Tag"),
+                ),
+            ],
+            options={
+                "verbose_name": "D2 Daemon",
+                "verbose_name_plural": "D2 Daemons",
+                "ordering": ("name",),
+            },
+            bases=(netbox.models.deletion.DeleteMixin, models.Model),
+        ),
+        migrations.CreateModel(
+            name="DDNSPolicy",
+            fields=[
+                (
+                    "id",
+                    models.BigAutoField(auto_created=True, primary_key=True, serialize=False),
+                ),
+                ("created", models.DateTimeField(auto_now_add=True, null=True)),
+                ("last_updated", models.DateTimeField(auto_now=True, null=True)),
+                (
+                    "custom_field_data",
+                    models.JSONField(
+                        blank=True,
+                        default=dict,
+                        encoder=utilities.json.CustomFieldJSONEncoder,
+                    ),
+                ),
+                ("name", models.CharField(max_length=100, unique=True)),
+                ("description", models.CharField(blank=True, max_length=200)),
+                ("ddns_send_updates", models.BooleanField(blank=True, null=True)),
+                ("ddns_override_no_update", models.BooleanField(blank=True, null=True)),
+                (
+                    "ddns_override_client_update",
+                    models.BooleanField(blank=True, null=True),
+                ),
+                (
+                    "ddns_replace_client_name",
+                    models.CharField(blank=True, default="", max_length=20),
+                ),
+                (
+                    "ddns_generated_prefix",
+                    models.CharField(blank=True, default="", max_length=255),
+                ),
+                (
+                    "ddns_qualifying_suffix",
+                    models.CharField(blank=True, default="", max_length=255),
+                ),
+                (
+                    "hostname_char_set",
+                    models.CharField(blank=True, default="", max_length=255),
+                ),
+                (
+                    "hostname_char_replacement",
+                    models.CharField(blank=True, default="", max_length=255),
+                ),
+                ("ddns_update_on_renew", models.BooleanField(blank=True, null=True)),
+                (
+                    "ddns_conflict_resolution_mode",
+                    models.CharField(blank=True, default="", max_length=32),
+                ),
+                (
+                    "ddns_ttl_percent",
+                    models.DecimalField(blank=True, decimal_places=4, max_digits=6, null=True),
+                ),
+                ("ddns_ttl", models.PositiveIntegerField(blank=True, null=True)),
+                ("ddns_ttl_min", models.PositiveIntegerField(blank=True, null=True)),
+                ("ddns_ttl_max", models.PositiveIntegerField(blank=True, null=True)),
+                (
+                    "tags",
+                    taggit.managers.TaggableManager(through="extras.TaggedItem", to="extras.Tag"),
+                ),
+            ],
+            options={
+                "verbose_name": "DDNS Policy",
+                "verbose_name_plural": "DDNS Policies",
+                "ordering": ("name",),
+            },
+            bases=(netbox.models.deletion.DeleteMixin, models.Model),
+        ),
+        migrations.CreateModel(
+            name="DDNSDomain",
+            fields=[
+                (
+                    "id",
+                    models.BigAutoField(auto_created=True, primary_key=True, serialize=False),
+                ),
+                ("created", models.DateTimeField(auto_now_add=True, null=True)),
+                ("last_updated", models.DateTimeField(auto_now=True, null=True)),
+                (
+                    "custom_field_data",
+                    models.JSONField(
+                        blank=True,
+                        default=dict,
+                        encoder=utilities.json.CustomFieldJSONEncoder,
+                    ),
+                ),
+                (
+                    "d2_daemon",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="domains",
+                        to="netbox_dhcp_kea_plugin.d2daemon",
+                    ),
+                ),
+                (
+                    "zone",
+                    models.ForeignKey(
+                        db_constraint=False,
+                        on_delete=django.db.models.deletion.PROTECT,
+                        related_name="+",
+                        to="netbox_dns.zone",
+                    ),
+                ),
+                (
+                    "tsig_key",
+                    models.ForeignKey(
+                        blank=True,
+                        null=True,
+                        on_delete=django.db.models.deletion.SET_NULL,
+                        related_name="domains",
+                        to="netbox_dhcp_kea_plugin.tsigkey",
+                    ),
+                ),
+                (
+                    "tags",
+                    taggit.managers.TaggableManager(through="extras.TaggedItem", to="extras.Tag"),
+                ),
+            ],
+            options={
+                "verbose_name": "DDNS Domain",
+                "verbose_name_plural": "DDNS Domains",
+                "ordering": ("d2_daemon", "zone"),
+                "unique_together": {("d2_daemon", "zone")},
+            },
+            bases=(netbox.models.deletion.DeleteMixin, models.Model),
+        ),
+        migrations.AddField(
+            model_name="dhcpserver",
+            name="d2_daemon",
+            field=models.ForeignKey(
+                blank=True,
+                null=True,
+                on_delete=django.db.models.deletion.SET_NULL,
+                related_name="servers",
+                to="netbox_dhcp_kea_plugin.d2daemon",
+            ),
+        ),
+        migrations.AddField(
+            model_name="dhcpserver",
+            name="ddns_enable_updates",
+            field=models.BooleanField(default=True),
+        ),
+        migrations.AddField(
+            model_name="dhcpserver",
+            name="ddns_sender_ip",
+            field=models.CharField(blank=True, default="", max_length=45),
+        ),
+        migrations.AddField(
+            model_name="dhcpserver",
+            name="ddns_sender_port",
+            field=models.PositiveIntegerField(blank=True, null=True),
+        ),
+        migrations.AddField(
+            model_name="dhcpserver",
+            name="ddns_policy",
+            field=models.ForeignKey(
+                blank=True,
+                null=True,
+                on_delete=django.db.models.deletion.SET_NULL,
+                related_name="servers",
+                to="netbox_dhcp_kea_plugin.ddnspolicy",
+            ),
+        ),
+        migrations.AddField(
+            model_name="dhcpharelationship",
+            name="d2_daemon",
+            field=models.ForeignKey(
+                blank=True,
+                null=True,
+                on_delete=django.db.models.deletion.SET_NULL,
+                related_name="ha_relationships",
+                to="netbox_dhcp_kea_plugin.d2daemon",
+            ),
+        ),
+        migrations.AddField(
+            model_name="dhcpharelationship",
+            name="ddns_enable_updates",
+            field=models.BooleanField(default=True),
+        ),
+        migrations.AddField(
+            model_name="dhcpharelationship",
+            name="ddns_sender_ip",
+            field=models.CharField(blank=True, default="", max_length=45),
+        ),
+        migrations.AddField(
+            model_name="dhcpharelationship",
+            name="ddns_sender_port",
+            field=models.PositiveIntegerField(blank=True, null=True),
+        ),
+        migrations.AddField(
+            model_name="subnet",
+            name="ddns_policy",
+            field=models.ForeignKey(
+                blank=True,
+                null=True,
+                on_delete=django.db.models.deletion.SET_NULL,
+                related_name="subnets",
+                to="netbox_dhcp_kea_plugin.ddnspolicy",
+            ),
+        ),
+        migrations.AddField(
+            model_name="clientclass",
+            name="ddns_policy",
+            field=models.ForeignKey(
+                blank=True,
+                null=True,
+                on_delete=django.db.models.deletion.SET_NULL,
+                related_name="client_classes",
+                to="netbox_dhcp_kea_plugin.ddnspolicy",
+            ),
+        ),
+    ]

--- a/netbox_dhcp_kea_plugin/migrations/0006_ddns.py
+++ b/netbox_dhcp_kea_plugin/migrations/0006_ddns.py
@@ -284,13 +284,14 @@ class Migration(migrations.Migration):
         ),
         migrations.AddField(
             model_name="dhcpharelationship",
-            name="ddns_sender_ip",
-            field=models.CharField(blank=True, default="", max_length=45),
-        ),
-        migrations.AddField(
-            model_name="dhcpharelationship",
-            name="ddns_sender_port",
-            field=models.PositiveIntegerField(blank=True, null=True),
+            name="ddns_policy",
+            field=models.ForeignKey(
+                blank=True,
+                null=True,
+                on_delete=django.db.models.deletion.SET_NULL,
+                related_name="ha_relationships",
+                to="netbox_dhcp_kea_plugin.ddnspolicy",
+            ),
         ),
         migrations.AddField(
             model_name="subnet",

--- a/netbox_dhcp_kea_plugin/models.py
+++ b/netbox_dhcp_kea_plugin/models.py
@@ -316,6 +316,40 @@ class DHCPServer(NetBoxModel):
         related_name="servers",
         help_text="Stork agent group configuration for this DHCP server",
     )
+    d2_daemon = models.ForeignKey(
+        "D2Daemon",
+        on_delete=models.SET_NULL,
+        null=True,
+        blank=True,
+        related_name="servers",
+        help_text=(
+            "D2 daemon this server forwards NCRs to. Ignored when the server "
+            "is in an HA relationship whose ``d2_daemon`` is set."
+        ),
+    )
+    ddns_enable_updates = models.BooleanField(
+        default=True,
+        help_text="Globally enable DDNS updates on this DHCP server (dhcp-ddns.enable-updates)",
+    )
+    ddns_sender_ip = models.CharField(
+        max_length=45,
+        blank=True,
+        default="",
+        help_text="Source IP the DHCP server uses to send NCRs (optional)",
+    )
+    ddns_sender_port = models.PositiveIntegerField(
+        null=True,
+        blank=True,
+        help_text="Source port the DHCP server uses to send NCRs (optional)",
+    )
+    ddns_policy = models.ForeignKey(
+        "DDNSPolicy",
+        on_delete=models.SET_NULL,
+        null=True,
+        blank=True,
+        related_name="servers",
+        help_text="Server-level DDNS policy (ddns-* tunables)",
+    )
 
     # Control Socket
     CTRL_SOCKET_TYPE_CHOICES = (
@@ -585,6 +619,51 @@ class DHCPServer(NetBoxModel):
             return None
 
         return self.ha_relationship.to_kea_dict(this_server=self)
+
+    @property
+    def effective_d2_daemon(self):
+        """Return the D2Daemon that actually applies to this server.
+
+        HA precedence: if the server is in an HA relationship whose
+        ``d2_daemon`` is set, that wins — peers must agree on the
+        ``dhcp-ddns`` block.
+        """
+        if self.ha_relationship_id and self.ha_relationship.d2_daemon_id:
+            return self.ha_relationship.d2_daemon
+        return self.d2_daemon
+
+    def _effective_ddns_field(self, name, blank_sentinel=""):
+        """Resolve a DDNS scalar with HA precedence.
+
+        When the server is in an HA relationship whose ``d2_daemon`` is set,
+        the relationship's value wins so peers stay in sync. Otherwise the
+        server's own value is used. ``blank_sentinel`` lets callers treat
+        empty strings as "unset" without overriding meaningful zero/False
+        values on numeric/boolean fields.
+        """
+        if self.ha_relationship_id and self.ha_relationship.d2_daemon_id:
+            return getattr(self.ha_relationship, name)
+        return getattr(self, name)
+
+    def effective_ddns_block(self):
+        """Build the ``dhcp-ddns`` block for kea-dhcp4/6, or None if not configured."""
+        daemon = self.effective_d2_daemon
+        if daemon is None:
+            return None
+        block = {
+            "enable-updates": self._effective_ddns_field("ddns_enable_updates"),
+            "server-ip": daemon.listener_ip,
+            "server-port": daemon.port,
+            "ncr-protocol": daemon.ncr_protocol,
+            "ncr-format": daemon.ncr_format,
+        }
+        sender_ip = self._effective_ddns_field("ddns_sender_ip")
+        if sender_ip:
+            block["sender-ip"] = sender_ip
+        sender_port = self._effective_ddns_field("ddns_sender_port")
+        if sender_port is not None:
+            block["sender-port"] = sender_port
+        return block
 
     def get_ha_primary(self):
         """Get the primary server in this server's HA relationship, if any.
@@ -1042,6 +1121,16 @@ class DHCPServer(NetBoxModel):
 
         if hooks_libraries:
             dhcp4["hooks-libraries"] = hooks_libraries
+
+        # DDNS: emit connection block + server-level policy overrides.
+        # Kea resolves the override chain at packet-processing time —
+        # subnet- and class-level overrides are emitted separately in
+        # Subnet.to_kea_dict() / ClientClass.to_kea_dict().
+        ddns_block = self.effective_ddns_block()
+        if ddns_block is not None:
+            dhcp4["dhcp-ddns"] = ddns_block
+        if self.ddns_policy_id is not None:
+            dhcp4.update(self.ddns_policy.to_kea_overrides())
 
         return result
 
@@ -1681,6 +1770,14 @@ class ClientClass(NetBoxModel):
     )
     server_hostname = models.CharField(max_length=255, blank=True, help_text="Server hostname for PXE boot (sname)")
     boot_file_name = models.CharField(max_length=255, blank=True, help_text="Boot file name for PXE boot (file)")
+    ddns_policy = models.ForeignKey(
+        "DDNSPolicy",
+        on_delete=models.SET_NULL,
+        null=True,
+        blank=True,
+        related_name="client_classes",
+        help_text="Class-level DDNS policy overrides (ddns-* tunables)",
+    )
 
     class Meta:
         ordering = ("name",)
@@ -1894,6 +1991,9 @@ class ClientClass(NetBoxModel):
         if self.boot_file_name:
             result["boot-file-name"] = self.boot_file_name
 
+        if self.ddns_policy_id is not None:
+            result.update(self.ddns_policy.to_kea_overrides())
+
         return result
 
     def to_kea_json(self, ascii_format=False, indent=4):
@@ -1982,6 +2082,14 @@ class Subnet(NetBoxModel):
         default=get_default_reservations_only,
         verbose_name="Reservations Only",
         help_text="Disable dynamic pool allocation — only reserved hosts will receive an IP from this subnet",
+    )
+    ddns_policy = models.ForeignKey(
+        "DDNSPolicy",
+        on_delete=models.SET_NULL,
+        null=True,
+        blank=True,
+        related_name="subnets",
+        help_text="Subnet-level DDNS policy overrides (ddns-* tunables)",
     )
 
     class Meta:
@@ -2445,6 +2553,9 @@ class Subnet(NetBoxModel):
             if reservations:
                 result["reservations"] = reservations
 
+        if self.ddns_policy_id is not None:
+            result.update(self.ddns_policy.to_kea_overrides())
+
         return result
 
 
@@ -2653,6 +2764,32 @@ class DHCPHARelationship(NetBoxModel):
     http_client_threads = models.PositiveIntegerField(default=4, help_text="Number of HTTP client threads (0 = auto)")
 
     description = models.CharField(max_length=200, blank=True)
+    d2_daemon = models.ForeignKey(
+        "D2Daemon",
+        on_delete=models.SET_NULL,
+        null=True,
+        blank=True,
+        related_name="ha_relationships",
+        help_text=(
+            "D2 daemon shared by all peers in this HA relationship. "
+            "When set, overrides each member server's standalone d2_daemon."
+        ),
+    )
+    ddns_enable_updates = models.BooleanField(
+        default=True,
+        help_text="DDNS enable-updates value used by all peers in this HA relationship",
+    )
+    ddns_sender_ip = models.CharField(
+        max_length=45,
+        blank=True,
+        default="",
+        help_text="Source IP all peers use to send NCRs (optional)",
+    )
+    ddns_sender_port = models.PositiveIntegerField(
+        null=True,
+        blank=True,
+        help_text="Source port all peers use to send NCRs (optional)",
+    )
 
     class Meta:
         ordering = ("name",)
@@ -3239,3 +3376,467 @@ class StorkAgentGroup(NetBoxModel):
         if self.stork_server:
             return self.stork_server.url
         return None
+
+
+# ---------------------------------------------------------------------------
+# DDNS (kea-dhcp-ddns / D2) — models
+# ---------------------------------------------------------------------------
+
+TSIG_ALGORITHM_CHOICES = (
+    ("HMAC-MD5", "HMAC-MD5"),
+    ("HMAC-SHA1", "HMAC-SHA1"),
+    ("HMAC-SHA224", "HMAC-SHA224"),
+    ("HMAC-SHA256", "HMAC-SHA256"),
+    ("HMAC-SHA384", "HMAC-SHA384"),
+    ("HMAC-SHA512", "HMAC-SHA512"),
+)
+
+TSIG_SECRET_BACKEND_CHOICES = (
+    ("plaintext", "Plaintext (stored in NetBox DB)"),
+    ("vault", "HashiCorp Vault (by path reference)"),
+)
+
+NCR_PROTOCOL_CHOICES = (
+    ("UDP", "UDP"),
+    ("TCP", "TCP"),
+)
+
+NCR_FORMAT_CHOICES = (
+    ("JSON", "JSON"),
+)
+
+DDNS_REPLACE_CLIENT_NAME_CHOICES = (
+    ("never", "never"),
+    ("always", "always"),
+    ("when-present", "when-present"),
+    ("when-not-present", "when-not-present"),
+)
+
+# Kea 3.0+ — ddns-conflict-resolution-mode replaces the deprecated
+# boolean ddns-use-conflict-resolution. Do not emit the deprecated alias.
+DDNS_CONFLICT_RESOLUTION_MODE_CHOICES = (
+    ("check-with-dhcid", "check-with-dhcid"),
+    ("no-check-with-dhcid", "no-check-with-dhcid"),
+    ("check-exists-with-dhcid", "check-exists-with-dhcid"),
+    ("no-check-without-dhcid", "no-check-without-dhcid"),
+)
+
+
+class TSIGKey(NetBoxModel):
+    """RFC 2845 TSIG key used to authenticate DNS UPDATE messages sent by D2.
+
+    Secret storage is delegated to a pluggable backend (see
+    ``secret_backends.py``) so the v1 plaintext model can be replaced later
+    by Vault / external secret retrieval without any schema change.
+    """
+
+    name = models.CharField(
+        max_length=255,
+        unique=True,
+        help_text="TSIG key name as it appears in Kea (e.g. 'd2.example.com.')",
+    )
+    description = models.CharField(max_length=200, blank=True)
+    algorithm = models.CharField(
+        max_length=20,
+        choices=TSIG_ALGORITHM_CHOICES,
+        default="HMAC-SHA256",
+        help_text="TSIG HMAC algorithm",
+    )
+    digest_bits = models.PositiveIntegerField(
+        null=True,
+        blank=True,
+        help_text="Truncated digest length in bits (optional; default is full length)",
+    )
+    secret_backend = models.CharField(
+        max_length=20,
+        choices=TSIG_SECRET_BACKEND_CHOICES,
+        default="plaintext",
+        help_text="Where the raw secret is sourced from at config-emission time",
+    )
+    secret_plaintext = models.CharField(
+        max_length=512,
+        blank=True,
+        default="",
+        help_text="Base64-encoded TSIG secret (used when backend is 'plaintext')",
+    )
+    secret_ref = models.CharField(
+        max_length=512,
+        blank=True,
+        default="",
+        help_text="External reference (e.g. Vault path) — used when backend is non-plaintext",
+    )
+
+    class Meta:
+        ordering = ("name",)
+        verbose_name = "TSIG Key"
+        verbose_name_plural = "TSIG Keys"
+        permissions = [
+            ("view_secret_tsigkey", "Can view TSIG key plaintext secret"),
+        ]
+
+    def __str__(self):
+        return self.name
+
+    def get_absolute_url(self):
+        return reverse("plugins:netbox_dhcp_kea_plugin:tsigkey", args=[self.pk])
+
+    def clean(self):
+        super().clean()
+        errors = {}
+
+        if self.secret_backend == "plaintext":
+            if not self.secret_plaintext:
+                errors["secret_plaintext"] = "Plaintext backend requires a secret."
+            else:
+                # Must be valid base64
+                import base64 as _base64
+                import binascii as _binascii
+
+                try:
+                    _base64.b64decode(self.secret_plaintext, validate=True)
+                except (_binascii.Error, ValueError):
+                    errors["secret_plaintext"] = "Secret must be valid base64."
+        else:
+            if not self.secret_ref:
+                errors["secret_ref"] = (
+                    f"Backend '{self.secret_backend}' requires a reference."
+                )
+
+        # Digest-bits must be a positive multiple of 8 when set, and never
+        # exceed the underlying algorithm's natural output.
+        if self.digest_bits is not None:
+            if self.digest_bits <= 0 or self.digest_bits % 8:
+                errors["digest_bits"] = "digest_bits must be a positive multiple of 8."
+            max_bits = {
+                "HMAC-MD5": 128,
+                "HMAC-SHA1": 160,
+                "HMAC-SHA224": 224,
+                "HMAC-SHA256": 256,
+                "HMAC-SHA384": 384,
+                "HMAC-SHA512": 512,
+            }.get(self.algorithm)
+            if max_bits and self.digest_bits > max_bits:
+                errors["digest_bits"] = (
+                    f"digest_bits ({self.digest_bits}) exceeds algorithm output "
+                    f"size ({max_bits})."
+                )
+
+        if errors:
+            raise ValidationError(errors)
+
+    def get_secret(self):
+        """Resolve the raw (base64) secret via the configured backend."""
+        from .secret_backends import resolve_secret
+
+        return resolve_secret(self)
+
+    def to_kea_dict(self):
+        """Emit the Kea tsig-keys entry for this key.
+
+        Only called at config-emission time — the caller is expected to have
+        the ``view_secret_tsigkey`` permission or to be rendering to a
+        deployment pipeline.
+        """
+        entry = {
+            "name": self.name,
+            "algorithm": self.algorithm.lower(),
+            "secret": self.get_secret(),
+        }
+        if self.digest_bits:
+            entry["digest-bits"] = self.digest_bits
+        return entry
+
+
+class D2Daemon(NetBoxModel):
+    """A kea-dhcp-ddns (D2) daemon instance.
+
+    Models the listener socket, control socket, and NCR (NameChangeRequest)
+    transport for one D2 process. DDNSDomain rows attached to this daemon
+    become entries under ``forward-ddns.ddns-domains`` / ``reverse-ddns.ddns-domains``
+    in the emitted ``kea-dhcp-ddns.conf``.
+    """
+
+    name = models.CharField(max_length=100, unique=True)
+    description = models.CharField(max_length=200, blank=True)
+    ip_address = models.ForeignKey(
+        IPAddress,
+        on_delete=models.PROTECT,
+        related_name="d2_daemons",
+        help_text="IP address the D2 daemon listens on for NameChangeRequests",
+    )
+    port = models.PositiveIntegerField(
+        default=53001,
+        help_text="Port the D2 daemon listens on (default: 53001)",
+    )
+    control_socket_path = models.CharField(
+        max_length=512,
+        blank=True,
+        default="",
+        help_text="Unix domain socket path for D2 control channel (optional)",
+    )
+    ncr_protocol = models.CharField(
+        max_length=3,
+        choices=NCR_PROTOCOL_CHOICES,
+        default="UDP",
+        help_text="NameChangeRequest transport protocol",
+    )
+    ncr_format = models.CharField(
+        max_length=4,
+        choices=NCR_FORMAT_CHOICES,
+        default="JSON",
+        help_text="NameChangeRequest wire format",
+    )
+
+    class Meta:
+        ordering = ("name",)
+        verbose_name = "D2 Daemon"
+        verbose_name_plural = "D2 Daemons"
+
+    def __str__(self):
+        return self.name
+
+    def get_absolute_url(self):
+        return reverse("plugins:netbox_dhcp_kea_plugin:d2daemon", args=[self.pk])
+
+    @property
+    def listener_ip(self):
+        if self.ip_address is None:
+            return None
+        return str(self.ip_address.address.ip)
+
+    def to_kea_dict(self):
+        """Emit a full ``kea-dhcp-ddns.conf`` dictionary for this D2 daemon.
+
+        Domains are partitioned into forward/reverse based on the zone name
+        (``.in-addr.arpa`` or ``.ip6.arpa`` ⇒ reverse).
+        """
+        forward_domains = []
+        reverse_domains = []
+        tsig_keys = {}
+
+        for domain in self.domains.select_related("zone", "tsig_key").prefetch_related("zone__nameservers"):
+            domain_dict = domain.to_kea_dict()
+            if domain.is_reverse:
+                reverse_domains.append(domain_dict)
+            else:
+                forward_domains.append(domain_dict)
+            if domain.tsig_key_id and domain.tsig_key.name not in tsig_keys:
+                tsig_keys[domain.tsig_key.name] = domain.tsig_key.to_kea_dict()
+
+        dhcp_ddns = {
+            "ip-address": self.listener_ip,
+            "port": self.port,
+            "ncr-protocol": self.ncr_protocol,
+            "ncr-format": self.ncr_format,
+        }
+        if self.control_socket_path:
+            dhcp_ddns["control-socket"] = {
+                "socket-type": "unix",
+                "socket-name": self.control_socket_path,
+            }
+        if tsig_keys:
+            dhcp_ddns["tsig-keys"] = list(tsig_keys.values())
+        dhcp_ddns["forward-ddns"] = {"ddns-domains": forward_domains}
+        dhcp_ddns["reverse-ddns"] = {"ddns-domains": reverse_domains}
+
+        return {"DhcpDdns": dhcp_ddns}
+
+
+class DDNSDomain(NetBoxModel):
+    """A single forward or reverse DDNS domain entry on a D2 daemon.
+
+    Direction (forward vs reverse) is **derived** from the linked netbox-dns
+    Zone's name — a zone ending in ``.in-addr.arpa`` or ``.ip6.arpa`` is
+    reverse. This avoids the footgun of the direction field drifting out of
+    sync with the zone.
+    """
+
+    d2_daemon = models.ForeignKey(
+        "D2Daemon",
+        on_delete=models.CASCADE,
+        related_name="domains",
+        help_text="The D2 daemon that handles this domain",
+    )
+    # Zone and NameServer are FK'd through django's string-form model
+    # references with db_constraint=False so the plugin still migrates
+    # cleanly when netbox_dns isn't installed. Startup gating in
+    # __init__.py blocks enable_ddns=True without netbox_dns, so these
+    # columns are only ever populated when netbox_dns is present.
+    zone = models.ForeignKey(
+        "netbox_dns.Zone",
+        on_delete=models.PROTECT,
+        related_name="+",
+        db_constraint=False,
+        help_text="Forward or reverse zone that this domain serves",
+    )
+    tsig_key = models.ForeignKey(
+        "TSIGKey",
+        on_delete=models.SET_NULL,
+        null=True,
+        blank=True,
+        related_name="domains",
+        help_text="TSIG key for authenticating updates (optional)",
+    )
+
+    class Meta:
+        ordering = ("d2_daemon", "zone")
+        verbose_name = "DDNS Domain"
+        verbose_name_plural = "DDNS Domains"
+        unique_together = (("d2_daemon", "zone"),)
+
+    def __str__(self):
+        return f"{self.zone} @ {self.d2_daemon}"
+
+    def get_absolute_url(self):
+        return reverse("plugins:netbox_dhcp_kea_plugin:ddnsdomain", args=[self.pk])
+
+    @property
+    def is_reverse(self):
+        if self.zone_id is None:
+            return False
+        name = (self.zone.name or "").rstrip(".").lower()
+        return name.endswith(".in-addr.arpa") or name.endswith(".ip6.arpa") or name in (
+            "in-addr.arpa",
+            "ip6.arpa",
+        )
+
+    @staticmethod
+    def _resolve_nameserver_ips(ns_name):
+        """Resolve a nameserver FQDN to its A/AAAA IPs via netbox_dns.
+
+        Returns a list of IP strings (may be empty if no records exist or
+        netbox_dns isn't installed).
+        """
+        try:
+            from netbox_dns.models import Record as DNSRecord
+        except ImportError:
+            return []
+
+        fqdn = ns_name if ns_name.endswith(".") else f"{ns_name}."
+        ips = []
+        for rec in DNSRecord.objects.filter(fqdn=fqdn, type__in=("A", "AAAA")):
+            value = rec.value
+            if value and value not in ips:
+                ips.append(value)
+        return ips
+
+    def to_kea_dict(self):
+        """Emit a single ddns-domains entry.
+
+        ``dns-servers`` is derived from ``zone.nameservers`` — for each
+        NameServer the linked A/AAAA records in netbox_dns are resolved to
+        IPs. Nameservers with no resolvable IPs are silently skipped (Kea
+        requires IPs, not hostnames).
+        """
+        zone_name = self.zone.name
+        if not zone_name.endswith("."):
+            zone_name = zone_name + "."
+
+        dns_servers = []
+        for ns in self.zone.nameservers.all():
+            for ip in self._resolve_nameserver_ips(ns.name):
+                dns_servers.append({"ip-address": ip, "port": 53})
+
+        entry = {
+            "name": zone_name,
+            "dns-servers": dns_servers,
+        }
+        if self.tsig_key_id:
+            entry["key-name"] = self.tsig_key.name
+        return entry
+
+
+class DDNSPolicy(NetBoxModel):
+    """A reusable set of ``ddns-*`` override keys.
+
+    Attachable at any of server / subnet / client-class. Only non-null
+    fields are emitted at config-generation time — the Kea resolver itself
+    walks the override chain when processing packets. The plugin does
+    **not** merge layers in Python.
+    """
+
+    name = models.CharField(max_length=100, unique=True)
+    description = models.CharField(max_length=200, blank=True)
+
+    # Field name → Kea key mapping is done by to_kea_overrides() below.
+    ddns_send_updates = models.BooleanField(null=True, blank=True)
+    ddns_override_no_update = models.BooleanField(null=True, blank=True)
+    ddns_override_client_update = models.BooleanField(null=True, blank=True)
+    ddns_replace_client_name = models.CharField(
+        max_length=20,
+        choices=DDNS_REPLACE_CLIENT_NAME_CHOICES,
+        blank=True,
+        default="",
+        help_text="When Kea should replace the client-supplied FQDN",
+    )
+    ddns_generated_prefix = models.CharField(max_length=255, blank=True, default="")
+    ddns_qualifying_suffix = models.CharField(max_length=255, blank=True, default="")
+    hostname_char_set = models.CharField(max_length=255, blank=True, default="")
+    hostname_char_replacement = models.CharField(max_length=255, blank=True, default="")
+    ddns_update_on_renew = models.BooleanField(null=True, blank=True)
+    ddns_conflict_resolution_mode = models.CharField(
+        max_length=32,
+        choices=DDNS_CONFLICT_RESOLUTION_MODE_CHOICES,
+        blank=True,
+        default="",
+        help_text="Kea 3.0+ conflict resolution mode (replaces ddns-use-conflict-resolution)",
+    )
+    ddns_ttl_percent = models.DecimalField(
+        max_digits=6,
+        decimal_places=4,
+        null=True,
+        blank=True,
+        help_text="TTL as a fraction of lease lifetime (e.g. 0.3333 → 33%)",
+    )
+    ddns_ttl = models.PositiveIntegerField(null=True, blank=True)
+    ddns_ttl_min = models.PositiveIntegerField(null=True, blank=True)
+    ddns_ttl_max = models.PositiveIntegerField(null=True, blank=True)
+
+    class Meta:
+        ordering = ("name",)
+        verbose_name = "DDNS Policy"
+        verbose_name_plural = "DDNS Policies"
+
+    def __str__(self):
+        return self.name
+
+    def get_absolute_url(self):
+        return reverse("plugins:netbox_dhcp_kea_plugin:ddnspolicy", args=[self.pk])
+
+    # Kea key names are the kebab-cased Django field names — list the
+    # mapping explicitly for any that don't map trivially.
+    _KEA_FIELD_MAP = (
+        ("ddns_send_updates", "ddns-send-updates"),
+        ("ddns_override_no_update", "ddns-override-no-update"),
+        ("ddns_override_client_update", "ddns-override-client-update"),
+        ("ddns_replace_client_name", "ddns-replace-client-name"),
+        ("ddns_generated_prefix", "ddns-generated-prefix"),
+        ("ddns_qualifying_suffix", "ddns-qualifying-suffix"),
+        ("hostname_char_set", "hostname-char-set"),
+        ("hostname_char_replacement", "hostname-char-replacement"),
+        ("ddns_update_on_renew", "ddns-update-on-renew"),
+        ("ddns_conflict_resolution_mode", "ddns-conflict-resolution-mode"),
+        ("ddns_ttl_percent", "ddns-ttl-percent"),
+        ("ddns_ttl", "ddns-ttl"),
+        ("ddns_ttl_min", "ddns-ttl-min"),
+        ("ddns_ttl_max", "ddns-ttl-max"),
+    )
+
+    def to_kea_overrides(self):
+        """Return only the non-null/non-blank keys, kebab-cased for Kea.
+
+        String fields use ``""`` to mean "not set" (so they can round-trip
+        through CharField without null=True quirks). Decimals are emitted
+        as floats to match Kea's JSON schema.
+        """
+        result = {}
+        for field_name, kea_key in self._KEA_FIELD_MAP:
+            value = getattr(self, field_name)
+            if value is None:
+                continue
+            if isinstance(value, str) and value == "":
+                continue
+            if field_name == "ddns_ttl_percent":
+                value = float(value)
+            result[kea_key] = value
+        return result

--- a/netbox_dhcp_kea_plugin/models.py
+++ b/netbox_dhcp_kea_plugin/models.py
@@ -324,7 +324,7 @@ class DHCPServer(NetBoxModel):
         related_name="servers",
         help_text=(
             "D2 daemon this server forwards NCRs to. Ignored when the server "
-            "is in an HA relationship whose ``d2_daemon`` is set."
+            "is in an HA relationship with the field set."
         ),
     )
     ddns_enable_updates = models.BooleanField(
@@ -3401,9 +3401,7 @@ NCR_PROTOCOL_CHOICES = (
     ("TCP", "TCP"),
 )
 
-NCR_FORMAT_CHOICES = (
-    ("JSON", "JSON"),
-)
+NCR_FORMAT_CHOICES = (("JSON", "JSON"),)
 
 DDNS_REPLACE_CLIENT_NAME_CHOICES = (
     ("never", "never"),
@@ -3530,9 +3528,7 @@ class TSIGKey(NetBoxModel):
             self._normalize_secret()
         else:
             if not self.secret_ref:
-                errors["secret_ref"] = (
-                    f"Backend '{self.secret_backend}' requires a reference."
-                )
+                errors["secret_ref"] = f"Backend '{self.secret_backend}' requires a reference."
 
         # Digest-bits must be a positive multiple of 8 when set, and never
         # exceed the underlying algorithm's natural output.
@@ -3548,10 +3544,7 @@ class TSIGKey(NetBoxModel):
                 "HMAC-SHA512": 512,
             }.get(self.algorithm)
             if max_bits and self.digest_bits > max_bits:
-                errors["digest_bits"] = (
-                    f"digest_bits ({self.digest_bits}) exceeds algorithm output "
-                    f"size ({max_bits})."
-                )
+                errors["digest_bits"] = f"digest_bits ({self.digest_bits}) exceeds algorithm output size ({max_bits})."
 
         if errors:
             raise ValidationError(errors)
@@ -3727,9 +3720,14 @@ class DDNSDomain(NetBoxModel):
         if self.zone_id is None:
             return False
         name = (self.zone.name or "").rstrip(".").lower()
-        return name.endswith(".in-addr.arpa") or name.endswith(".ip6.arpa") or name in (
-            "in-addr.arpa",
-            "ip6.arpa",
+        return (
+            name.endswith(".in-addr.arpa")
+            or name.endswith(".ip6.arpa")
+            or name
+            in (
+                "in-addr.arpa",
+                "ip6.arpa",
+            )
         )
 
     @staticmethod

--- a/netbox_dhcp_kea_plugin/models.py
+++ b/netbox_dhcp_kea_plugin/models.py
@@ -3457,7 +3457,11 @@ class TSIGKey(NetBoxModel):
         max_length=512,
         blank=True,
         default="",
-        help_text="Base64-encoded TSIG secret (used when backend is 'plaintext')",
+        help_text=(
+            "Base64-encoded TSIG secret (used when backend is 'plaintext'). "
+            "Leave blank or enter any non-base64 text to auto-generate a fresh "
+            "random secret matching the selected algorithm."
+        ),
     )
     secret_ref = models.CharField(
         max_length=512,
@@ -3480,22 +3484,50 @@ class TSIGKey(NetBoxModel):
     def get_absolute_url(self):
         return reverse("plugins:netbox_dhcp_kea_plugin:tsigkey", args=[self.pk])
 
+    _ALGORITHM_BYTE_LEN = {
+        "HMAC-MD5": 16,
+        "HMAC-SHA1": 20,
+        "HMAC-SHA224": 28,
+        "HMAC-SHA256": 32,
+        "HMAC-SHA384": 48,
+        "HMAC-SHA512": 64,
+    }
+
+    def _generate_secret(self):
+        import base64 as _base64
+        import secrets as _secrets
+
+        nbytes = self._ALGORITHM_BYTE_LEN.get(self.algorithm, 32)
+        return _base64.b64encode(_secrets.token_bytes(nbytes)).decode()
+
+    def _normalize_secret(self):
+        """If plaintext secret isn't valid base64 of the algorithm's natural
+        length, replace it with a freshly generated one. Idempotent."""
+        if self.secret_backend != "plaintext":
+            return
+        import base64 as _base64
+        import binascii as _binascii
+
+        expected_len = self._ALGORITHM_BYTE_LEN.get(self.algorithm)
+        if self.secret_plaintext:
+            try:
+                decoded = _base64.b64decode(self.secret_plaintext, validate=True)
+                if expected_len is None or len(decoded) == expected_len:
+                    return
+            except (_binascii.Error, ValueError):
+                pass
+        self.secret_plaintext = self._generate_secret()
+
+    def save(self, *args, **kwargs):
+        self._normalize_secret()
+        return super().save(*args, **kwargs)
+
     def clean(self):
         super().clean()
         errors = {}
 
         if self.secret_backend == "plaintext":
-            if not self.secret_plaintext:
-                errors["secret_plaintext"] = "Plaintext backend requires a secret."
-            else:
-                # Must be valid base64
-                import base64 as _base64
-                import binascii as _binascii
-
-                try:
-                    _base64.b64decode(self.secret_plaintext, validate=True)
-                except (_binascii.Error, ValueError):
-                    errors["secret_plaintext"] = "Secret must be valid base64."
+            self._normalize_secret()
         else:
             if not self.secret_ref:
                 errors["secret_ref"] = (

--- a/netbox_dhcp_kea_plugin/models.py
+++ b/netbox_dhcp_kea_plugin/models.py
@@ -3594,13 +3594,32 @@ class D2Daemon(NetBoxModel):
     in the emitted ``kea-dhcp-ddns.conf``.
     """
 
+    LISTENER_MODE_LOCAL = "local"
+    LISTENER_MODE_REMOTE = "remote"
+    LISTENER_MODE_CHOICES = (
+        (LISTENER_MODE_LOCAL, "Local (127.0.0.1, deployed per peer)"),
+        (LISTENER_MODE_REMOTE, "Remote (single shared instance)"),
+    )
+
     name = models.CharField(max_length=100, unique=True)
     description = models.CharField(max_length=200, blank=True)
+    listener_mode = models.CharField(
+        max_length=10,
+        choices=LISTENER_MODE_CHOICES,
+        default=LISTENER_MODE_LOCAL,
+        help_text=(
+            "'Local' renders ip-address=127.0.0.1; deploy one D2 instance "
+            "on every host running kea-dhcp4/6 that uses this row. "
+            "'Remote' uses the IPAM-tracked listener address."
+        ),
+    )
     ip_address = models.ForeignKey(
         IPAddress,
         on_delete=models.PROTECT,
+        null=True,
+        blank=True,
         related_name="d2_daemons",
-        help_text="IP address the D2 daemon listens on for NameChangeRequests",
+        help_text="IP address the D2 daemon listens on (required only when listener_mode is 'remote')",
     )
     port = models.PositiveIntegerField(
         default=53001,
@@ -3636,8 +3655,19 @@ class D2Daemon(NetBoxModel):
     def get_absolute_url(self):
         return reverse("plugins:netbox_dhcp_kea_plugin:d2daemon", args=[self.pk])
 
+    def clean(self):
+        super().clean()
+        if self.listener_mode == self.LISTENER_MODE_REMOTE and self.ip_address is None:
+            from django.core.exceptions import ValidationError
+
+            raise ValidationError(
+                {"ip_address": "Required when listener mode is 'remote'."}
+            )
+
     @property
     def listener_ip(self):
+        if self.listener_mode == self.LISTENER_MODE_LOCAL:
+            return "127.0.0.1"
         if self.ip_address is None:
             return None
         return str(self.ip_address.address.ip)

--- a/netbox_dhcp_kea_plugin/models.py
+++ b/netbox_dhcp_kea_plugin/models.py
@@ -632,6 +632,18 @@ class DHCPServer(NetBoxModel):
             return self.ha_relationship.d2_daemon
         return self.d2_daemon
 
+    @property
+    def effective_ddns_policy(self):
+        """Return the DDNSPolicy that actually applies to this server.
+
+        HA precedence: when the server is in an HA relationship whose
+        ``ddns_policy`` is set, that wins so peers emit identical
+        ``ddns-*`` overrides at the Dhcp4/6 root level.
+        """
+        if self.ha_relationship_id and self.ha_relationship.ddns_policy_id:
+            return self.ha_relationship.ddns_policy
+        return self.ddns_policy
+
     def _effective_ddns_field(self, name, blank_sentinel=""):
         """Resolve a DDNS scalar with HA precedence.
 
@@ -657,12 +669,12 @@ class DHCPServer(NetBoxModel):
             "ncr-protocol": daemon.ncr_protocol,
             "ncr-format": daemon.ncr_format,
         }
-        sender_ip = self._effective_ddns_field("ddns_sender_ip")
-        if sender_ip:
-            block["sender-ip"] = sender_ip
-        sender_port = self._effective_ddns_field("ddns_sender_port")
-        if sender_port is not None:
-            block["sender-port"] = sender_port
+        # Sender IP/port are per-server (the local source endpoint that
+        # sends NCRs), not shared across HA peers — read directly from self.
+        if self.ddns_sender_ip:
+            block["sender-ip"] = self.ddns_sender_ip
+        if self.ddns_sender_port is not None:
+            block["sender-port"] = self.ddns_sender_port
         return block
 
     def get_ha_primary(self):
@@ -1129,8 +1141,9 @@ class DHCPServer(NetBoxModel):
         ddns_block = self.effective_ddns_block()
         if ddns_block is not None:
             dhcp4["dhcp-ddns"] = ddns_block
-        if self.ddns_policy_id is not None:
-            dhcp4.update(self.ddns_policy.to_kea_overrides())
+        eff_policy = self.effective_ddns_policy
+        if eff_policy is not None:
+            dhcp4.update(eff_policy.to_kea_overrides())
 
         return result
 
@@ -2779,16 +2792,16 @@ class DHCPHARelationship(NetBoxModel):
         default=True,
         help_text="DDNS enable-updates value used by all peers in this HA relationship",
     )
-    ddns_sender_ip = models.CharField(
-        max_length=45,
-        blank=True,
-        default="",
-        help_text="Source IP all peers use to send NCRs (optional)",
-    )
-    ddns_sender_port = models.PositiveIntegerField(
+    ddns_policy = models.ForeignKey(
+        "DDNSPolicy",
+        on_delete=models.SET_NULL,
         null=True,
         blank=True,
-        help_text="Source port all peers use to send NCRs (optional)",
+        related_name="ha_relationships",
+        help_text=(
+            "DDNS policy shared by all peers in this HA relationship. "
+            "When set, overrides each member server's standalone ddns_policy."
+        ),
     )
 
     class Meta:

--- a/netbox_dhcp_kea_plugin/navigation.py
+++ b/netbox_dhcp_kea_plugin/navigation.py
@@ -263,17 +263,6 @@ _menu_groups = [
     ),
 ]
 
-if enable_stork:
-    _menu_groups.append(
-        (
-            "Stork Monitoring",
-            (
-                storkserver_menu_item,
-                storkagentgroup_menu_item,
-            ),
-        ),
-    )
-
 if enable_ddns:
     _menu_groups.append(
         (
@@ -283,6 +272,17 @@ if enable_ddns:
                 d2daemon_menu_item,
                 ddnsdomain_menu_item,
                 ddnspolicy_menu_item,
+            ),
+        ),
+    )
+
+if enable_stork:
+    _menu_groups.append(
+        (
+            "Stork Monitoring",
+            (
+                storkserver_menu_item,
+                storkagentgroup_menu_item,
             ),
         ),
     )
@@ -306,8 +306,6 @@ else:
         optiondata_menu_item,
         vendoroptionspace_menu_item,
     ]
-    if enable_stork:
-        _flat_items.extend([storkserver_menu_item, storkagentgroup_menu_item])
     if enable_ddns:
         _flat_items.extend(
             [
@@ -317,4 +315,7 @@ else:
                 ddnspolicy_menu_item,
             ]
         )
+    if enable_stork:
+        _flat_items.extend([storkserver_menu_item, storkagentgroup_menu_item])
+
     menu_items = tuple(_flat_items)

--- a/netbox_dhcp_kea_plugin/navigation.py
+++ b/netbox_dhcp_kea_plugin/navigation.py
@@ -4,6 +4,7 @@ from netbox.plugins.utils import get_plugin_config
 menu_name = get_plugin_config("netbox_dhcp_kea_plugin", "menu_name")
 top_level_menu = get_plugin_config("netbox_dhcp_kea_plugin", "top_level_menu")
 enable_stork = get_plugin_config("netbox_dhcp_kea_plugin", "enable_stork")
+enable_ddns = get_plugin_config("netbox_dhcp_kea_plugin", "enable_ddns")
 
 # Define menu items
 hook_menu_item = PluginMenuItem(
@@ -174,6 +175,64 @@ storkagentgroup_menu_item = PluginMenuItem(
     ),
 )
 
+# --- DDNS Menu Items ---
+
+tsigkey_menu_item = PluginMenuItem(
+    link="plugins:netbox_dhcp_kea_plugin:tsigkey_list",
+    link_text="TSIG Keys",
+    permissions=["netbox_dhcp_kea_plugin.view_tsigkey"],
+    buttons=(
+        PluginMenuButton(
+            link="plugins:netbox_dhcp_kea_plugin:tsigkey_add",
+            title="Add",
+            icon_class="mdi mdi-plus-thick",
+            permissions=["netbox_dhcp_kea_plugin.add_tsigkey"],
+        ),
+    ),
+)
+
+d2daemon_menu_item = PluginMenuItem(
+    link="plugins:netbox_dhcp_kea_plugin:d2daemon_list",
+    link_text="D2 Daemons",
+    permissions=["netbox_dhcp_kea_plugin.view_d2daemon"],
+    buttons=(
+        PluginMenuButton(
+            link="plugins:netbox_dhcp_kea_plugin:d2daemon_add",
+            title="Add",
+            icon_class="mdi mdi-plus-thick",
+            permissions=["netbox_dhcp_kea_plugin.add_d2daemon"],
+        ),
+    ),
+)
+
+ddnsdomain_menu_item = PluginMenuItem(
+    link="plugins:netbox_dhcp_kea_plugin:ddnsdomain_list",
+    link_text="DDNS Domains",
+    permissions=["netbox_dhcp_kea_plugin.view_ddnsdomain"],
+    buttons=(
+        PluginMenuButton(
+            link="plugins:netbox_dhcp_kea_plugin:ddnsdomain_add",
+            title="Add",
+            icon_class="mdi mdi-plus-thick",
+            permissions=["netbox_dhcp_kea_plugin.add_ddnsdomain"],
+        ),
+    ),
+)
+
+ddnspolicy_menu_item = PluginMenuItem(
+    link="plugins:netbox_dhcp_kea_plugin:ddnspolicy_list",
+    link_text="DDNS Policies",
+    permissions=["netbox_dhcp_kea_plugin.view_ddnspolicy"],
+    buttons=(
+        PluginMenuButton(
+            link="plugins:netbox_dhcp_kea_plugin:ddnspolicy_add",
+            title="Add",
+            icon_class="mdi mdi-plus-thick",
+            permissions=["netbox_dhcp_kea_plugin.add_ddnspolicy"],
+        ),
+    ),
+)
+
 
 # Build menu groups, conditionally including Stork
 _menu_groups = [
@@ -215,6 +274,19 @@ if enable_stork:
         ),
     )
 
+if enable_ddns:
+    _menu_groups.append(
+        (
+            "DDNS",
+            (
+                tsigkey_menu_item,
+                d2daemon_menu_item,
+                ddnsdomain_menu_item,
+                ddnspolicy_menu_item,
+            ),
+        ),
+    )
+
 if top_level_menu:
     menu = PluginMenu(
         label=menu_name,
@@ -236,4 +308,13 @@ else:
     ]
     if enable_stork:
         _flat_items.extend([storkserver_menu_item, storkagentgroup_menu_item])
+    if enable_ddns:
+        _flat_items.extend(
+            [
+                tsigkey_menu_item,
+                d2daemon_menu_item,
+                ddnsdomain_menu_item,
+                ddnspolicy_menu_item,
+            ]
+        )
     menu_items = tuple(_flat_items)

--- a/netbox_dhcp_kea_plugin/secret_backends.py
+++ b/netbox_dhcp_kea_plugin/secret_backends.py
@@ -1,0 +1,56 @@
+"""TSIG key secret backends.
+
+Abstracts secret storage so a future Vault / external-secret backend can be
+plugged in without schema changes. v1 ships only the ``plaintext`` backend,
+which returns the value stored in ``TSIGKey.secret_plaintext`` verbatim.
+
+Register additional backends by calling ``register_backend(name, resolver)``
+where ``resolver`` is a callable ``(tsig_key) -> str``.
+"""
+
+from netbox.plugins.utils import get_plugin_config
+
+
+class TSIGSecretBackendError(Exception):
+    """Raised when a secret cannot be resolved by the configured backend."""
+
+
+def _plaintext_backend(tsig_key):
+    if not tsig_key.secret_plaintext:
+        raise TSIGSecretBackendError(
+            f"TSIG key '{tsig_key.name}' has no plaintext secret stored."
+        )
+    return tsig_key.secret_plaintext
+
+
+TSIG_SECRET_BACKENDS = {
+    "plaintext": _plaintext_backend,
+}
+
+
+def register_backend(name, resolver):
+    """Register a new secret backend.
+
+    ``resolver`` receives the ``TSIGKey`` instance and must return the raw
+    secret as a string.
+    """
+    TSIG_SECRET_BACKENDS[name] = resolver
+
+
+def resolve_secret(tsig_key):
+    """Resolve the raw secret for a TSIGKey via its configured backend.
+
+    Falls back to the plugin-wide default (``ddns_secret_backend``) when the
+    key doesn't pin its own backend.
+    """
+    backend_name = tsig_key.secret_backend or get_plugin_config(
+        "netbox_dhcp_kea_plugin", "ddns_secret_backend"
+    )
+    try:
+        backend = TSIG_SECRET_BACKENDS[backend_name]
+    except KeyError as exc:
+        raise TSIGSecretBackendError(
+            f"Unknown TSIG secret backend '{backend_name}'. "
+            f"Available: {sorted(TSIG_SECRET_BACKENDS)}"
+        ) from exc
+    return backend(tsig_key)

--- a/netbox_dhcp_kea_plugin/tables.py
+++ b/netbox_dhcp_kea_plugin/tables.py
@@ -3,6 +3,9 @@ from netbox.tables import BooleanColumn, ChoiceFieldColumn, NetBoxTable
 
 from .models import (
     ClientClass,
+    D2Daemon,
+    DDNSDomain,
+    DDNSPolicy,
     DHCPHARelationship,
     DHCPServer,
     Hook,
@@ -13,6 +16,7 @@ from .models import (
     StorkServer,
     Subnet,
     SubnetPool,
+    TSIGKey,
     VendorOptionSpace,
 )
 
@@ -653,5 +657,147 @@ class StorkAgentGroupTable(NetBoxTable):
             "agent_port",
             "prometheus_exporter_port",
             "servers_count",
+        )
+        exclude = ("id",)
+
+
+# --- DDNS Tables ---
+
+
+class TSIGKeyTable(NetBoxTable):
+    name = tables.Column(linkify=True, verbose_name="Name")
+    algorithm = tables.Column(verbose_name="Algorithm")
+    digest_bits = tables.Column(verbose_name="Digest Bits")
+    secret_backend = tables.Column(verbose_name="Secret Backend")
+    description = tables.Column(verbose_name="Description")
+
+    class Meta(NetBoxTable.Meta):
+        model = TSIGKey
+        fields = (
+            "pk",
+            "name",
+            "algorithm",
+            "digest_bits",
+            "secret_backend",
+            "description",
+            "actions",
+        )
+        default_columns = (
+            "name",
+            "algorithm",
+            "secret_backend",
+            "description",
+        )
+        exclude = ("id",)
+
+
+class D2DaemonTable(NetBoxTable):
+    name = tables.Column(linkify=True, verbose_name="Name")
+    ip_address = tables.Column(linkify=True, verbose_name="Listener IP")
+    port = tables.Column(verbose_name="Port")
+    ncr_protocol = tables.Column(verbose_name="NCR Protocol")
+    ncr_format = tables.Column(verbose_name="NCR Format")
+    domains_count = tables.Column(
+        verbose_name="Domains",
+        accessor="domains__count",
+        orderable=False,
+        linkify=False,
+    )
+    description = tables.Column(verbose_name="Description")
+
+    class Meta(NetBoxTable.Meta):
+        model = D2Daemon
+        fields = (
+            "pk",
+            "name",
+            "ip_address",
+            "port",
+            "ncr_protocol",
+            "ncr_format",
+            "domains_count",
+            "description",
+            "actions",
+        )
+        default_columns = (
+            "name",
+            "ip_address",
+            "port",
+            "ncr_protocol",
+            "domains_count",
+        )
+        exclude = ("id",)
+
+
+class DDNSDomainTable(NetBoxTable):
+    d2_daemon = tables.Column(linkify=True, verbose_name="D2 Daemon")
+    zone = tables.Column(linkify=True, verbose_name="Zone")
+    tsig_key = tables.Column(linkify=True, verbose_name="TSIG Key")
+    is_reverse = BooleanColumn(verbose_name="Reverse")
+
+    class Meta(NetBoxTable.Meta):
+        model = DDNSDomain
+        fields = (
+            "pk",
+            "d2_daemon",
+            "zone",
+            "tsig_key",
+            "is_reverse",
+            "actions",
+        )
+        default_columns = (
+            "d2_daemon",
+            "zone",
+            "tsig_key",
+            "is_reverse",
+        )
+        exclude = ("id",)
+
+
+class DDNSPolicyTable(NetBoxTable):
+    name = tables.Column(linkify=True, verbose_name="Name")
+    ddns_send_updates = BooleanColumn(verbose_name="Send Updates")
+    ddns_qualifying_suffix = tables.Column(verbose_name="Qualifying Suffix")
+    ddns_conflict_resolution_mode = tables.Column(verbose_name="Conflict Mode")
+    servers_count = tables.Column(
+        verbose_name="Servers",
+        accessor="servers__count",
+        orderable=False,
+        linkify=False,
+    )
+    subnets_count = tables.Column(
+        verbose_name="Subnets",
+        accessor="subnets__count",
+        orderable=False,
+        linkify=False,
+    )
+    client_classes_count = tables.Column(
+        verbose_name="Client Classes",
+        accessor="client_classes__count",
+        orderable=False,
+        linkify=False,
+    )
+    description = tables.Column(verbose_name="Description")
+
+    class Meta(NetBoxTable.Meta):
+        model = DDNSPolicy
+        fields = (
+            "pk",
+            "name",
+            "ddns_send_updates",
+            "ddns_qualifying_suffix",
+            "ddns_conflict_resolution_mode",
+            "servers_count",
+            "subnets_count",
+            "client_classes_count",
+            "description",
+            "actions",
+        )
+        default_columns = (
+            "name",
+            "ddns_send_updates",
+            "ddns_qualifying_suffix",
+            "servers_count",
+            "subnets_count",
+            "client_classes_count",
         )
         exclude = ("id",)

--- a/netbox_dhcp_kea_plugin/tables.py
+++ b/netbox_dhcp_kea_plugin/tables.py
@@ -693,6 +693,7 @@ class TSIGKeyTable(NetBoxTable):
 
 class D2DaemonTable(NetBoxTable):
     name = tables.Column(linkify=True, verbose_name="Name")
+    listener_mode = tables.Column(verbose_name="Mode")
     ip_address = tables.Column(linkify=True, verbose_name="Listener IP")
     port = tables.Column(verbose_name="Port")
     ncr_protocol = tables.Column(verbose_name="NCR Protocol")
@@ -710,6 +711,7 @@ class D2DaemonTable(NetBoxTable):
         fields = (
             "pk",
             "name",
+            "listener_mode",
             "ip_address",
             "port",
             "ncr_protocol",
@@ -720,6 +722,7 @@ class D2DaemonTable(NetBoxTable):
         )
         default_columns = (
             "name",
+            "listener_mode",
             "ip_address",
             "port",
             "ncr_protocol",

--- a/netbox_dhcp_kea_plugin/templates/netbox_dhcp_kea_plugin/clientclass.html
+++ b/netbox_dhcp_kea_plugin/templates/netbox_dhcp_kea_plugin/clientclass.html
@@ -44,6 +44,18 @@
                         <td>{{ object.boot_file_name }}</td>
                     </tr>
                     {% endif %}
+                    {% if enable_ddns %}
+                    <tr>
+                        <th>DDNS Policy</th>
+                        <td>
+                            {% if object.ddns_policy %}
+                            <a href="{{ object.ddns_policy.get_absolute_url }}">{{ object.ddns_policy.name }}</a>
+                            {% else %}
+                            <span class="text-muted">None</span>
+                            {% endif %}
+                        </td>
+                    </tr>
+                    {% endif %}
                 </table>
             </div>
         </div>

--- a/netbox_dhcp_kea_plugin/templates/netbox_dhcp_kea_plugin/d2daemon.html
+++ b/netbox_dhcp_kea_plugin/templates/netbox_dhcp_kea_plugin/d2daemon.html
@@ -1,0 +1,63 @@
+{% extends 'generic/object.html' %}
+{% load helpers %}
+
+{% block content %}
+<div class="row">
+    <div class="col col-md-6">
+        <div class="card">
+            <h5 class="card-header">D2 Daemon</h5>
+            <div class="card-body">
+                <table class="table table-hover attr-table">
+                    <tr>
+                        <th>Name</th>
+                        <td>{{ object.name }}</td>
+                    </tr>
+                    <tr>
+                        <th>Description</th>
+                        <td>{{ object.description|placeholder }}</td>
+                    </tr>
+                    <tr>
+                        <th>IP Address</th>
+                        <td>
+                            {% if object.ip_address %}
+                            <a href="{{ object.ip_address.get_absolute_url }}">{{ object.ip_address }}</a>
+                            {% else %}
+                            {{ ''|placeholder }}
+                            {% endif %}
+                        </td>
+                    </tr>
+                    <tr>
+                        <th>Port</th>
+                        <td>{{ object.port }}</td>
+                    </tr>
+                </table>
+            </div>
+        </div>
+    </div>
+    <div class="col col-md-6">
+        <div class="card">
+            <h5 class="card-header">NCR Settings</h5>
+            <div class="card-body">
+                <table class="table table-hover attr-table">
+                    <tr>
+                        <th>Control Socket Path</th>
+                        <td>{{ object.control_socket_path|placeholder }}</td>
+                    </tr>
+                    <tr>
+                        <th>NCR Protocol</th>
+                        <td>{{ object.get_ncr_protocol_display }}</td>
+                    </tr>
+                    <tr>
+                        <th>NCR Format</th>
+                        <td>{{ object.get_ncr_format_display }}</td>
+                    </tr>
+                    <tr>
+                        <th>Domains</th>
+                        <td>{{ object.domains.count }}</td>
+                    </tr>
+                </table>
+            </div>
+        </div>
+    </div>
+</div>
+{% endblock %}

--- a/netbox_dhcp_kea_plugin/templates/netbox_dhcp_kea_plugin/d2daemon.html
+++ b/netbox_dhcp_kea_plugin/templates/netbox_dhcp_kea_plugin/d2daemon.html
@@ -17,9 +17,16 @@
                         <td>{{ object.description|placeholder }}</td>
                     </tr>
                     <tr>
-                        <th>IP Address</th>
+                        <th>Listener Mode</th>
+                        <td>{{ object.get_listener_mode_display }}</td>
+                    </tr>
+                    <tr>
+                        <th>Listener Address</th>
                         <td>
-                            {% if object.ip_address %}
+                            {% if object.listener_mode == "local" %}
+                            <span>127.0.0.1</span>
+                            <small class="text-muted">— deploy one D2 instance per host running kea-dhcp4/6</small>
+                            {% elif object.ip_address %}
                             <a href="{{ object.ip_address.get_absolute_url }}">{{ object.ip_address }}</a>
                             {% else %}
                             {{ ''|placeholder }}

--- a/netbox_dhcp_kea_plugin/templates/netbox_dhcp_kea_plugin/d2daemon_config.html
+++ b/netbox_dhcp_kea_plugin/templates/netbox_dhcp_kea_plugin/d2daemon_config.html
@@ -1,0 +1,31 @@
+{% extends 'generic/object.html' %}
+{% load helpers %}
+{% load builtins.tags %}
+
+{% block head %}
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/github.min.css">
+<script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/highlight.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/languages/json.min.js"></script>
+{% endblock %}
+
+{% block content %}
+<div class="row">
+    <div class="col col-md-12">
+        <div class="card mb-3">
+            <h2 class="card-header d-flex justify-content-between">
+                <span>/api/plugins/netbox_dhcp_kea_plugin/d2-daemons/{{ object.pk }}/kea-config/</span>
+                <div>
+                    {% copy_content "d2-config" %}
+                </div>
+            </h2>
+            <pre class="card-body mb-0 language-json" id="d2-config">{{ config_json }}</pre>
+        </div>
+    </div>
+</div>
+
+<script>
+document.addEventListener('DOMContentLoaded', function() {
+    hljs.highlightAll();
+});
+</script>
+{% endblock %}

--- a/netbox_dhcp_kea_plugin/templates/netbox_dhcp_kea_plugin/d2daemon_domains.html
+++ b/netbox_dhcp_kea_plugin/templates/netbox_dhcp_kea_plugin/d2daemon_domains.html
@@ -1,0 +1,50 @@
+{% extends 'generic/object.html' %}
+{% load helpers %}
+
+{% block content %}
+<div class="row">
+    <div class="col col-md-12">
+        {% if domains %}
+        <div class="card">
+            <h5 class="card-header">DDNS Domains</h5>
+            <div class="card-body">
+                <table class="table table-hover">
+                    <thead>
+                        <tr>
+                            <th>Zone</th>
+                            <th>Direction</th>
+                            <th>TSIG Key</th>
+                            <th>Nameservers</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {% for domain in domains %}
+                        <tr>
+                            <td><a href="{{ domain.get_absolute_url }}">{{ domain.zone }}</a></td>
+                            <td>{% if domain.is_reverse %}Reverse{% else %}Forward{% endif %}</td>
+                            <td>
+                                {% if domain.tsig_key %}
+                                <a href="{{ domain.tsig_key.get_absolute_url }}">{{ domain.tsig_key.name }}</a>
+                                {% else %}
+                                <span class="text-muted">—</span>
+                                {% endif %}
+                            </td>
+                            <td>
+                                {% for ns in domain.zone.nameservers.all %}
+                                {{ ns }}{% if not forloop.last %}, {% endif %}
+                                {% empty %}
+                                <span class="text-muted">—</span>
+                                {% endfor %}
+                            </td>
+                        </tr>
+                        {% endfor %}
+                    </tbody>
+                </table>
+            </div>
+        </div>
+        {% else %}
+        <div class="alert alert-info">No DDNS domains are attached to this D2 daemon.</div>
+        {% endif %}
+    </div>
+</div>
+{% endblock %}

--- a/netbox_dhcp_kea_plugin/templates/netbox_dhcp_kea_plugin/ddnsdomain.html
+++ b/netbox_dhcp_kea_plugin/templates/netbox_dhcp_kea_plugin/ddnsdomain.html
@@ -1,0 +1,57 @@
+{% extends 'generic/object.html' %}
+{% load helpers %}
+
+{% block content %}
+<div class="row">
+    <div class="col col-md-6">
+        <div class="card">
+            <h5 class="card-header">DDNS Domain</h5>
+            <div class="card-body">
+                <table class="table table-hover attr-table">
+                    <tr>
+                        <th>D2 Daemon</th>
+                        <td><a href="{{ object.d2_daemon.get_absolute_url }}">{{ object.d2_daemon.name }}</a></td>
+                    </tr>
+                    <tr>
+                        <th>Zone</th>
+                        <td>{{ object.zone }}</td>
+                    </tr>
+                    <tr>
+                        <th>Direction</th>
+                        <td>{% if object.is_reverse %}Reverse{% else %}Forward{% endif %}</td>
+                    </tr>
+                    <tr>
+                        <th>TSIG Key</th>
+                        <td>
+                            {% if object.tsig_key %}
+                            <a href="{{ object.tsig_key.get_absolute_url }}">{{ object.tsig_key.name }}</a>
+                            {% else %}
+                            {{ ''|placeholder }}
+                            {% endif %}
+                        </td>
+                    </tr>
+                </table>
+            </div>
+        </div>
+    </div>
+    <div class="col col-md-6">
+        <div class="card">
+            <h5 class="card-header">Zone Nameservers</h5>
+            <div class="card-body">
+                {% if object.zone and object.zone.nameservers.all %}
+                <ul class="list-unstyled mb-0">
+                    {% for ns in object.zone.nameservers.all %}
+                    <li>{{ ns }}</li>
+                    {% endfor %}
+                </ul>
+                <p class="text-muted small mt-2 mb-0">
+                    IPs are resolved at config-emit time from netbox-dns A/AAAA records.
+                </p>
+                {% else %}
+                <p class="text-muted mb-0">Zone has no nameservers assigned.</p>
+                {% endif %}
+            </div>
+        </div>
+    </div>
+</div>
+{% endblock %}

--- a/netbox_dhcp_kea_plugin/templates/netbox_dhcp_kea_plugin/ddnspolicy.html
+++ b/netbox_dhcp_kea_plugin/templates/netbox_dhcp_kea_plugin/ddnspolicy.html
@@ -1,0 +1,110 @@
+{% extends 'generic/object.html' %}
+{% load helpers %}
+
+{% block content %}
+<div class="row">
+    <div class="col col-md-6">
+        <div class="card">
+            <h5 class="card-header">DDNS Policy</h5>
+            <div class="card-body">
+                <table class="table table-hover attr-table">
+                    <tr>
+                        <th>Name</th>
+                        <td>{{ object.name }}</td>
+                    </tr>
+                    <tr>
+                        <th>Description</th>
+                        <td>{{ object.description|placeholder }}</td>
+                    </tr>
+                </table>
+            </div>
+        </div>
+        <div class="card mt-3">
+            <h5 class="card-header">Override Flags</h5>
+            <div class="card-body">
+                <table class="table table-hover attr-table">
+                    <tr>
+                        <th>Send Updates</th>
+                        <td>{{ object.ddns_send_updates|placeholder }}</td>
+                    </tr>
+                    <tr>
+                        <th>Override No Update</th>
+                        <td>{{ object.ddns_override_no_update|placeholder }}</td>
+                    </tr>
+                    <tr>
+                        <th>Override Client Update</th>
+                        <td>{{ object.ddns_override_client_update|placeholder }}</td>
+                    </tr>
+                    <tr>
+                        <th>Update On Renew</th>
+                        <td>{{ object.ddns_update_on_renew|placeholder }}</td>
+                    </tr>
+                    <tr>
+                        <th>Replace Client Name</th>
+                        <td>{{ object.ddns_replace_client_name|placeholder }}</td>
+                    </tr>
+                </table>
+            </div>
+        </div>
+    </div>
+    <div class="col col-md-6">
+        <div class="card">
+            <h5 class="card-header">Hostname</h5>
+            <div class="card-body">
+                <table class="table table-hover attr-table">
+                    <tr>
+                        <th>Generated Prefix</th>
+                        <td>{{ object.ddns_generated_prefix|placeholder }}</td>
+                    </tr>
+                    <tr>
+                        <th>Qualifying Suffix</th>
+                        <td>{{ object.ddns_qualifying_suffix|placeholder }}</td>
+                    </tr>
+                    <tr>
+                        <th>Hostname Char Set</th>
+                        <td>{{ object.hostname_char_set|placeholder }}</td>
+                    </tr>
+                    <tr>
+                        <th>Hostname Char Replacement</th>
+                        <td>{{ object.hostname_char_replacement|placeholder }}</td>
+                    </tr>
+                </table>
+            </div>
+        </div>
+        <div class="card mt-3">
+            <h5 class="card-header">Conflict Resolution</h5>
+            <div class="card-body">
+                <table class="table table-hover attr-table">
+                    <tr>
+                        <th>Mode</th>
+                        <td>{{ object.ddns_conflict_resolution_mode|placeholder }}</td>
+                    </tr>
+                </table>
+            </div>
+        </div>
+        <div class="card mt-3">
+            <h5 class="card-header">TTL</h5>
+            <div class="card-body">
+                <table class="table table-hover attr-table">
+                    <tr>
+                        <th>TTL Percent</th>
+                        <td>{{ object.ddns_ttl_percent|placeholder }}</td>
+                    </tr>
+                    <tr>
+                        <th>TTL</th>
+                        <td>{{ object.ddns_ttl|placeholder }}</td>
+                    </tr>
+                    <tr>
+                        <th>TTL Min</th>
+                        <td>{{ object.ddns_ttl_min|placeholder }}</td>
+                    </tr>
+                    <tr>
+                        <th>TTL Max</th>
+                        <td>{{ object.ddns_ttl_max|placeholder }}</td>
+                    </tr>
+                </table>
+            </div>
+        </div>
+    </div>
+</div>
+{% endblock %}

--- a/netbox_dhcp_kea_plugin/templates/netbox_dhcp_kea_plugin/ddnspolicy_clientclasses.html
+++ b/netbox_dhcp_kea_plugin/templates/netbox_dhcp_kea_plugin/ddnspolicy_clientclasses.html
@@ -1,0 +1,40 @@
+{% extends 'generic/object.html' %}
+{% load helpers %}
+
+{% block content %}
+<div class="row">
+    <div class="col col-md-12">
+        {% if client_classes %}
+        <div class="card">
+            <h5 class="card-header">Client Classes Using This Policy</h5>
+            <div class="card-body">
+                <table class="table table-hover">
+                    <thead>
+                        <tr>
+                            <th>Client Class</th>
+                            <th>Servers</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {% for cc in client_classes %}
+                        <tr>
+                            <td><a href="{{ cc.get_absolute_url }}">{{ cc.name }}</a></td>
+                            <td>
+                                {% for s in cc.servers.all %}
+                                <a href="{{ s.get_absolute_url }}">{{ s.name }}</a>{% if not forloop.last %}, {% endif %}
+                                {% empty %}
+                                <span class="text-muted">—</span>
+                                {% endfor %}
+                            </td>
+                        </tr>
+                        {% endfor %}
+                    </tbody>
+                </table>
+            </div>
+        </div>
+        {% else %}
+        <div class="alert alert-info">No client classes reference this policy.</div>
+        {% endif %}
+    </div>
+</div>
+{% endblock %}

--- a/netbox_dhcp_kea_plugin/templates/netbox_dhcp_kea_plugin/ddnspolicy_servers.html
+++ b/netbox_dhcp_kea_plugin/templates/netbox_dhcp_kea_plugin/ddnspolicy_servers.html
@@ -1,0 +1,36 @@
+{% extends 'generic/object.html' %}
+{% load helpers %}
+
+{% block content %}
+<div class="row">
+    <div class="col col-md-12">
+        {% if servers %}
+        <div class="card">
+            <h5 class="card-header">DHCP Servers Using This Policy</h5>
+            <div class="card-body">
+                <table class="table table-hover">
+                    <thead>
+                        <tr>
+                            <th>Server</th>
+                            <th>IP Address</th>
+                            <th>Status</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {% for server in servers %}
+                        <tr>
+                            <td><a href="{{ server.get_absolute_url }}">{{ server.name }}</a></td>
+                            <td>{{ server.ip_address|placeholder }}</td>
+                            <td>{% badge server.get_status_display bg_color=server.get_status_color %}</td>
+                        </tr>
+                        {% endfor %}
+                    </tbody>
+                </table>
+            </div>
+        </div>
+        {% else %}
+        <div class="alert alert-info">No DHCP servers reference this policy.</div>
+        {% endif %}
+    </div>
+</div>
+{% endblock %}

--- a/netbox_dhcp_kea_plugin/templates/netbox_dhcp_kea_plugin/ddnspolicy_subnets.html
+++ b/netbox_dhcp_kea_plugin/templates/netbox_dhcp_kea_plugin/ddnspolicy_subnets.html
@@ -1,0 +1,40 @@
+{% extends 'generic/object.html' %}
+{% load helpers %}
+
+{% block content %}
+<div class="row">
+    <div class="col col-md-12">
+        {% if subnets %}
+        <div class="card">
+            <h5 class="card-header">Subnets Using This Policy</h5>
+            <div class="card-body">
+                <table class="table table-hover">
+                    <thead>
+                        <tr>
+                            <th>Subnet</th>
+                            <th>Server</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {% for subnet in subnets %}
+                        <tr>
+                            <td><a href="{{ subnet.get_absolute_url }}">{{ subnet }}</a></td>
+                            <td>
+                                {% if subnet.server %}
+                                <a href="{{ subnet.server.get_absolute_url }}">{{ subnet.server.name }}</a>
+                                {% else %}
+                                <span class="text-muted">—</span>
+                                {% endif %}
+                            </td>
+                        </tr>
+                        {% endfor %}
+                    </tbody>
+                </table>
+            </div>
+        </div>
+        {% else %}
+        <div class="alert alert-info">No subnets reference this policy.</div>
+        {% endif %}
+    </div>
+</div>
+{% endblock %}

--- a/netbox_dhcp_kea_plugin/templates/netbox_dhcp_kea_plugin/dhcpharelationship.html
+++ b/netbox_dhcp_kea_plugin/templates/netbox_dhcp_kea_plugin/dhcpharelationship.html
@@ -61,6 +61,47 @@
                 </table>
             </div>
         </div>
+        {% if enable_ddns %}
+        <div class="card">
+            <h5 class="card-header">DDNS</h5>
+            <div class="card-body">
+                <table class="table table-hover attr-table">
+                    <tr>
+                        <th>D2 Daemon</th>
+                        <td>
+                            {% if object.d2_daemon %}
+                            <a href="{{ object.d2_daemon.get_absolute_url }}">{{ object.d2_daemon }}</a>
+                            {% else %}
+                            <span class="text-muted">None</span>
+                            {% endif %}
+                        </td>
+                    </tr>
+                    <tr>
+                        <th>Updates Enabled</th>
+                        <td>
+                            {% if object.ddns_enable_updates %}
+                            <i class="mdi mdi-check-bold text-success"></i>
+                            {% else %}
+                            <i class="mdi mdi-close-thick text-danger"></i>
+                            {% endif %}
+                        </td>
+                    </tr>
+                    {% if enable_ddns %}
+                    <tr>
+                        <th>DDNS Policy</th>
+                        <td>
+                            {% if object.ddns_policy %}
+                            <a href="{{ object.ddns_policy.get_absolute_url }}">{{ object.ddns_policy.name }}</a>
+                            {% else %}
+                            <span class="text-muted">None</span>
+                            {% endif %}
+                        </td>
+                    </tr>
+                    {% endif %}
+                </table>
+            </div>
+        </div>
+        {% endif %}
     </div>
     <div class="col col-md-6">
         <div class="card">

--- a/netbox_dhcp_kea_plugin/templates/netbox_dhcp_kea_plugin/dhcpserver.html
+++ b/netbox_dhcp_kea_plugin/templates/netbox_dhcp_kea_plugin/dhcpserver.html
@@ -128,10 +128,73 @@
                         </td>
                     </tr>
                     {% endif %}
-                    {% if enable_ddns %}
                     <tr>
-                        <th colspan="2" class="table-light">DDNS</th>
+                        <th>Control Socket</th>
+                        <td>
+                            {% if object.ctrl_socket_type %}
+                            {{ object.get_ctrl_socket_type_display }}
+                            {% else %}
+                            <span class="text-muted">Disabled</span>
+                            {% endif %}
+                        </td>
                     </tr>
+                    {% if object.ctrl_socket_http_enabled %}
+                    <tr>
+                        <th>HTTP Socket</th>
+                        <td>{{ object.ctrl_socket_http_address }}:{{ object.ctrl_socket_http_port }}</td>
+                    </tr>
+                    {% endif %}
+                    {% if object.ctrl_socket_unix_enabled %}
+                    <tr>
+                        <th>Unix Socket</th>
+                        <td>{{ object.ctrl_socket_unix_path }}</td>
+                    </tr>
+                    {% endif %}
+                </table>
+            </div>
+        </div>
+        <div class="card">
+            <h5 class="card-header">Reservation Mode Defaults</h5>
+            <div class="card-body">
+                <table class="table table-hover attr-table">
+                    <tr>
+                        <th>Reservations Global</th>
+                        <td>
+                            {% if object.reservations_global %}
+                            <i class="mdi mdi-check-bold text-success"></i>
+                            {% else %}
+                            <i class="mdi mdi-close-thick text-danger"></i>
+                            {% endif %}
+                        </td>
+                    </tr>
+                    <tr>
+                        <th>Reservations In-Subnet</th>
+                        <td>
+                            {% if object.reservations_in_subnet %}
+                            <i class="mdi mdi-check-bold text-success"></i>
+                            {% else %}
+                            <i class="mdi mdi-close-thick text-danger"></i>
+                            {% endif %}
+                        </td>
+                    </tr>
+                    <tr>
+                        <th>Reservations Out-of-Pool</th>
+                        <td>
+                            {% if object.reservations_out_of_pool %}
+                            <i class="mdi mdi-check-bold text-success"></i>
+                            {% else %}
+                            <i class="mdi mdi-close-thick text-danger"></i>
+                            {% endif %}
+                        </td>
+                    </tr>
+                </table>
+            </div>
+        </div>
+        {% if enable_ddns %}
+        <div class="card">
+            <h5 class="card-header">DDNS</h5>
+            <div class="card-body">
+                <table class="table table-hover attr-table">
                     <tr>
                         <th>D2 Daemon</th>
                         <td>
@@ -152,10 +215,18 @@
                         <td>
                             {% with src=object.ha_relationship %}
                             {% if src and src.d2_daemon_id %}
-                                {% if src.ddns_enable_updates %}Yes{% else %}No{% endif %}
+                                {% if object.ddns_enable_updates %}
+                                <i class="mdi mdi-check-bold text-success"></i>
+                                {% else %}
+                                <i class="mdi mdi-close-thick text-danger"></i>
+                                {% endif %}
                                 <span class="badge bg-info ms-1" style="color: #ffffff;">inherited from HA relationship</span>
                             {% else %}
-                                {% if object.ddns_enable_updates %}Yes{% else %}No{% endif %}
+                                {% if object.ddns_enable_updates %}
+                                <i class="mdi mdi-check-bold text-success"></i>
+                                {% else %}
+                                <i class="mdi mdi-close-thick text-danger"></i>
+                                {% endif %}
                             {% endif %}
                             {% endwith %}
                         </td>
@@ -191,65 +262,10 @@
                             {% endif %}
                         </td>
                     </tr>
-                    {% endif %}
-                    <tr>
-                        <th>Control Socket</th>
-                        <td>
-                            {% if object.ctrl_socket_type %}
-                            {{ object.get_ctrl_socket_type_display }}
-                            {% else %}
-                            <span class="text-muted">Disabled</span>
-                            {% endif %}
-                        </td>
-                    </tr>
-                    {% if object.ctrl_socket_http_enabled %}
-                    <tr>
-                        <th>HTTP Socket</th>
-                        <td>{{ object.ctrl_socket_http_address }}:{{ object.ctrl_socket_http_port }}</td>
-                    </tr>
-                    {% endif %}
-                    {% if object.ctrl_socket_unix_enabled %}
-                    <tr>
-                        <th>Unix Socket</th>
-                        <td>{{ object.ctrl_socket_unix_path }}</td>
-                    </tr>
-                    {% endif %}
-                    <tr>
-                        <th colspan="2" class="table-light">Reservation Mode Defaults</th>
-                    </tr>
-                    <tr>
-                        <th>Reservations Global</th>
-                        <td>
-                            {% if object.reservations_global %}
-                            <i class="mdi mdi-check-bold text-success"></i>
-                            {% else %}
-                            <i class="mdi mdi-close-thick text-danger"></i>
-                            {% endif %}
-                        </td>
-                    </tr>
-                    <tr>
-                        <th>Reservations In-Subnet</th>
-                        <td>
-                            {% if object.reservations_in_subnet %}
-                            <i class="mdi mdi-check-bold text-success"></i>
-                            {% else %}
-                            <i class="mdi mdi-close-thick text-danger"></i>
-                            {% endif %}
-                        </td>
-                    </tr>
-                    <tr>
-                        <th>Reservations Out-of-Pool</th>
-                        <td>
-                            {% if object.reservations_out_of_pool %}
-                            <i class="mdi mdi-check-bold text-success"></i>
-                            {% else %}
-                            <i class="mdi mdi-close-thick text-danger"></i>
-                            {% endif %}
-                        </td>
-                    </tr>
                 </table>
             </div>
         </div>
+        {% endif %}
         <div class="card mt-3">
             <h5 class="card-header">Configuration Summary</h5>
             <div class="card-body">

--- a/netbox_dhcp_kea_plugin/templates/netbox_dhcp_kea_plugin/dhcpserver.html
+++ b/netbox_dhcp_kea_plugin/templates/netbox_dhcp_kea_plugin/dhcpserver.html
@@ -128,6 +128,70 @@
                         </td>
                     </tr>
                     {% endif %}
+                    {% if enable_ddns %}
+                    <tr>
+                        <th colspan="2" class="table-light">DDNS</th>
+                    </tr>
+                    <tr>
+                        <th>D2 Daemon</th>
+                        <td>
+                            {% with eff=object.effective_d2_daemon %}
+                            {% if eff %}
+                            <a href="{{ eff.get_absolute_url }}">{{ eff.name }}</a>
+                            {% if object.ha_relationship and object.ha_relationship.d2_daemon_id == eff.id %}
+                            <span class="badge bg-info ms-1" style="color: #ffffff;">inherited from HA relationship</span>
+                            {% endif %}
+                            {% else %}
+                            <span class="text-muted">None</span>
+                            {% endif %}
+                            {% endwith %}
+                        </td>
+                    </tr>
+                    <tr>
+                        <th>Updates Enabled</th>
+                        <td>
+                            {% with src=object.ha_relationship %}
+                            {% if src and src.d2_daemon_id %}
+                                {% if src.ddns_enable_updates %}Yes{% else %}No{% endif %}
+                                <span class="badge bg-info ms-1" style="color: #ffffff;">inherited from HA relationship</span>
+                            {% else %}
+                                {% if object.ddns_enable_updates %}Yes{% else %}No{% endif %}
+                            {% endif %}
+                            {% endwith %}
+                        </td>
+                    </tr>
+                    <tr>
+                        <th>Sender</th>
+                        <td>
+                            {% with src=object.ha_relationship %}
+                            {% if src and src.d2_daemon_id %}
+                                {% if src.ddns_sender_ip or src.ddns_sender_port %}
+                                {{ src.ddns_sender_ip|default:"—" }}{% if src.ddns_sender_port %}:{{ src.ddns_sender_port }}{% endif %}
+                                <span class="badge bg-info ms-1" style="color: #ffffff;">inherited from HA relationship</span>
+                                {% else %}
+                                <span class="text-muted">—</span>
+                                {% endif %}
+                            {% else %}
+                                {% if object.ddns_sender_ip or object.ddns_sender_port %}
+                                {{ object.ddns_sender_ip|default:"—" }}{% if object.ddns_sender_port %}:{{ object.ddns_sender_port }}{% endif %}
+                                {% else %}
+                                <span class="text-muted">—</span>
+                                {% endif %}
+                            {% endif %}
+                            {% endwith %}
+                        </td>
+                    </tr>
+                    <tr>
+                        <th>DDNS Policy</th>
+                        <td>
+                            {% if object.ddns_policy %}
+                            <a href="{{ object.ddns_policy.get_absolute_url }}">{{ object.ddns_policy.name }}</a>
+                            {% else %}
+                            <span class="text-muted">None</span>
+                            {% endif %}
+                        </td>
+                    </tr>
+                    {% endif %}
                     <tr>
                         <th>Control Socket</th>
                         <td>

--- a/netbox_dhcp_kea_plugin/templates/netbox_dhcp_kea_plugin/dhcpserver.html
+++ b/netbox_dhcp_kea_plugin/templates/netbox_dhcp_kea_plugin/dhcpserver.html
@@ -202,7 +202,7 @@
                             {% if eff %}
                             <a href="{{ eff.get_absolute_url }}">{{ eff.name }}</a>
                             {% if object.ha_relationship and object.ha_relationship.d2_daemon_id == eff.id %}
-                            <span class="badge bg-info ms-1" style="color: #ffffff;">inherited from HA relationship</span>
+                            <span class="badge bg-info float-end" style="color: #ffffff;">inherited from HA relationship</span>
                             {% endif %}
                             {% else %}
                             <span class="text-muted">None</span>
@@ -220,7 +220,7 @@
                                 {% else %}
                                 <i class="mdi mdi-close-thick text-danger"></i>
                                 {% endif %}
-                                <span class="badge bg-info ms-1" style="color: #ffffff;">inherited from HA relationship</span>
+                                <span class="badge bg-info float-end" style="color: #ffffff;">inherited from HA relationship</span>
                             {% else %}
                                 {% if object.ddns_enable_updates %}
                                 <i class="mdi mdi-check-bold text-success"></i>
@@ -232,33 +232,27 @@
                         </td>
                     </tr>
                     <tr>
-                        <th>Sender</th>
+                        <th>DDNS Policy</th>
                         <td>
-                            {% with src=object.ha_relationship %}
-                            {% if src and src.d2_daemon_id %}
-                                {% if src.ddns_sender_ip or src.ddns_sender_port %}
-                                {{ src.ddns_sender_ip|default:"—" }}{% if src.ddns_sender_port %}:{{ src.ddns_sender_port }}{% endif %}
-                                <span class="badge bg-info ms-1" style="color: #ffffff;">inherited from HA relationship</span>
-                                {% else %}
-                                <span class="text-muted">—</span>
+                            {% with eff=object.effective_ddns_policy %}
+                            {% if eff %}
+                            <a href="{{ eff.get_absolute_url }}">{{ eff.name }}</a>
+                                {% if object.ha_relationship.ddns_policy_id %}
+                                <span class="badge bg-info float-end" style="color: #ffffff;">inherited from HA relationship</span>
                                 {% endif %}
                             {% else %}
-                                {% if object.ddns_sender_ip or object.ddns_sender_port %}
-                                {{ object.ddns_sender_ip|default:"—" }}{% if object.ddns_sender_port %}:{{ object.ddns_sender_port }}{% endif %}
-                                {% else %}
-                                <span class="text-muted">—</span>
-                                {% endif %}
+                            <span class="text-muted">None</span>
                             {% endif %}
                             {% endwith %}
                         </td>
                     </tr>
                     <tr>
-                        <th>DDNS Policy</th>
+                        <th>Sender</th>
                         <td>
-                            {% if object.ddns_policy %}
-                            <a href="{{ object.ddns_policy.get_absolute_url }}">{{ object.ddns_policy.name }}</a>
+                            {% if object.ddns_sender_ip or object.ddns_sender_port %}
+                            {{ object.ddns_sender_ip|default:"—" }}{% if object.ddns_sender_port %}:{{ object.ddns_sender_port }}{% endif %}
                             {% else %}
-                            <span class="text-muted">None</span>
+                            <span class="text-muted">—</span>
                             {% endif %}
                         </td>
                     </tr>

--- a/netbox_dhcp_kea_plugin/templates/netbox_dhcp_kea_plugin/subnet.html
+++ b/netbox_dhcp_kea_plugin/templates/netbox_dhcp_kea_plugin/subnet.html
@@ -45,6 +45,25 @@
                             {% endif %}
                         </td>
                     </tr>
+                    {% if enable_ddns %}
+                    <tr>
+                        <th>DDNS Policy</th>
+                        <td>
+                            {% if object.ddns_policy %}
+                            <a href="{{ object.ddns_policy.get_absolute_url }}">{{ object.ddns_policy.name }}</a>
+                            {% else %}
+                            <span class="text-muted">None</span>
+                            {% endif %}
+                        </td>
+                    </tr>
+                    {% endif %}
+                </table>
+            </div>
+        </div>
+        <div class="card">
+            <h5 class="card-header">Reservation Mode</h5>
+            <div class="card-body">
+                <table class="table table-hover attr-table">
                     <tr>
                         <th>Reservations Global</th>
                         <td>

--- a/netbox_dhcp_kea_plugin/templates/netbox_dhcp_kea_plugin/tsigkey.html
+++ b/netbox_dhcp_kea_plugin/templates/netbox_dhcp_kea_plugin/tsigkey.html
@@ -1,0 +1,85 @@
+{% extends 'generic/object.html' %}
+{% load helpers %}
+
+{% block content %}
+<div class="row">
+    <div class="col col-md-6">
+        <div class="card">
+            <h5 class="card-header">TSIG Key</h5>
+            <div class="card-body">
+                <table class="table table-hover attr-table">
+                    <tr>
+                        <th>Name</th>
+                        <td>{{ object.name }}</td>
+                    </tr>
+                    <tr>
+                        <th>Description</th>
+                        <td>{{ object.description|placeholder }}</td>
+                    </tr>
+                    <tr>
+                        <th>Algorithm</th>
+                        <td>{{ object.get_algorithm_display }}</td>
+                    </tr>
+                    <tr>
+                        <th>Digest Bits</th>
+                        <td>{{ object.digest_bits|placeholder }}</td>
+                    </tr>
+                </table>
+            </div>
+        </div>
+    </div>
+    <div class="col col-md-6">
+        <div class="card">
+            <h5 class="card-header">Secret</h5>
+            <div class="card-body">
+                <table class="table table-hover attr-table">
+                    <tr>
+                        <th>Backend</th>
+                        <td>{{ object.get_secret_backend_display }}</td>
+                    </tr>
+                    <tr>
+                        <th>Secret</th>
+                        <td>
+                            {% if can_view_secret %}
+                                {% if object.secret_backend == 'plaintext' %}
+                                    <span id="tsig-secret-masked">••••••••••</span>
+                                    <span id="tsig-secret-clear" style="display:none;">{{ object.secret_plaintext }}</span>
+                                    <button type="button" class="btn btn-sm btn-outline-secondary ms-2" id="tsig-secret-toggle">
+                                        <i class="mdi mdi-eye"></i> Reveal
+                                    </button>
+                                {% else %}
+                                    <span class="text-muted">{{ object.secret_ref|placeholder }}</span>
+                                {% endif %}
+                            {% else %}
+                                <span class="text-muted">Hidden (requires <em>view_secret_tsigkey</em> permission)</span>
+                            {% endif %}
+                        </td>
+                    </tr>
+                </table>
+            </div>
+        </div>
+    </div>
+</div>
+
+{% if can_view_secret %}
+<script>
+document.addEventListener('DOMContentLoaded', function() {
+    var btn = document.getElementById('tsig-secret-toggle');
+    if (!btn) return;
+    btn.addEventListener('click', function() {
+        var masked = document.getElementById('tsig-secret-masked');
+        var clear = document.getElementById('tsig-secret-clear');
+        if (clear.style.display === 'none') {
+            clear.style.display = '';
+            masked.style.display = 'none';
+            btn.innerHTML = '<i class="mdi mdi-eye-off"></i> Hide';
+        } else {
+            clear.style.display = 'none';
+            masked.style.display = '';
+            btn.innerHTML = '<i class="mdi mdi-eye"></i> Reveal';
+        }
+    });
+});
+</script>
+{% endif %}
+{% endblock %}

--- a/netbox_dhcp_kea_plugin/urls.py
+++ b/netbox_dhcp_kea_plugin/urls.py
@@ -292,3 +292,88 @@ if get_plugin_config("netbox_dhcp_kea_plugin", "enable_stork"):
             name="storkagentgroup_config",
         ),
     ]
+
+if get_plugin_config("netbox_dhcp_kea_plugin", "enable_ddns"):
+    urlpatterns += [
+        # TSIGKey URLs
+        path("tsig-keys/", views.TSIGKeyListView.as_view(), name="tsigkey_list"),
+        path("tsig-keys/add/", views.TSIGKeyEditView.as_view(), name="tsigkey_add"),
+        path("tsig-keys/import/", views.TSIGKeyImportView.as_view(), name="tsigkey_bulk_import"),
+        path("tsig-keys/delete/", views.TSIGKeyBulkDeleteView.as_view(), name="tsigkey_bulk_delete"),
+        path("tsig-keys/<int:pk>/", views.TSIGKeyView.as_view(), name="tsigkey"),
+        path("tsig-keys/<int:pk>/edit/", views.TSIGKeyEditView.as_view(), name="tsigkey_edit"),
+        path("tsig-keys/<int:pk>/delete/", views.TSIGKeyDeleteView.as_view(), name="tsigkey_delete"),
+        path(
+            "tsig-keys/<int:pk>/changelog/",
+            ObjectChangeLogView.as_view(),
+            name="tsigkey_changelog",
+            kwargs={"model": models.TSIGKey},
+        ),
+        # D2Daemon URLs
+        path("d2-daemons/", views.D2DaemonListView.as_view(), name="d2daemon_list"),
+        path("d2-daemons/add/", views.D2DaemonEditView.as_view(), name="d2daemon_add"),
+        path("d2-daemons/import/", views.D2DaemonImportView.as_view(), name="d2daemon_bulk_import"),
+        path("d2-daemons/delete/", views.D2DaemonBulkDeleteView.as_view(), name="d2daemon_bulk_delete"),
+        path("d2-daemons/<int:pk>/", views.D2DaemonView.as_view(), name="d2daemon"),
+        path("d2-daemons/<int:pk>/edit/", views.D2DaemonEditView.as_view(), name="d2daemon_edit"),
+        path("d2-daemons/<int:pk>/delete/", views.D2DaemonDeleteView.as_view(), name="d2daemon_delete"),
+        path(
+            "d2-daemons/<int:pk>/changelog/",
+            ObjectChangeLogView.as_view(),
+            name="d2daemon_changelog",
+            kwargs={"model": models.D2Daemon},
+        ),
+        path(
+            "d2-daemons/<int:pk>/domains/",
+            views.D2DaemonDomainsView.as_view(),
+            name="d2daemon_domains",
+        ),
+        path(
+            "d2-daemons/<int:pk>/config/",
+            views.D2DaemonConfigView.as_view(),
+            name="d2daemon_config",
+        ),
+        # DDNSDomain URLs
+        path("ddns-domains/", views.DDNSDomainListView.as_view(), name="ddnsdomain_list"),
+        path("ddns-domains/add/", views.DDNSDomainEditView.as_view(), name="ddnsdomain_add"),
+        path("ddns-domains/import/", views.DDNSDomainImportView.as_view(), name="ddnsdomain_bulk_import"),
+        path("ddns-domains/delete/", views.DDNSDomainBulkDeleteView.as_view(), name="ddnsdomain_bulk_delete"),
+        path("ddns-domains/<int:pk>/", views.DDNSDomainView.as_view(), name="ddnsdomain"),
+        path("ddns-domains/<int:pk>/edit/", views.DDNSDomainEditView.as_view(), name="ddnsdomain_edit"),
+        path("ddns-domains/<int:pk>/delete/", views.DDNSDomainDeleteView.as_view(), name="ddnsdomain_delete"),
+        path(
+            "ddns-domains/<int:pk>/changelog/",
+            ObjectChangeLogView.as_view(),
+            name="ddnsdomain_changelog",
+            kwargs={"model": models.DDNSDomain},
+        ),
+        # DDNSPolicy URLs
+        path("ddns-policies/", views.DDNSPolicyListView.as_view(), name="ddnspolicy_list"),
+        path("ddns-policies/add/", views.DDNSPolicyEditView.as_view(), name="ddnspolicy_add"),
+        path("ddns-policies/import/", views.DDNSPolicyImportView.as_view(), name="ddnspolicy_bulk_import"),
+        path("ddns-policies/delete/", views.DDNSPolicyBulkDeleteView.as_view(), name="ddnspolicy_bulk_delete"),
+        path("ddns-policies/<int:pk>/", views.DDNSPolicyView.as_view(), name="ddnspolicy"),
+        path("ddns-policies/<int:pk>/edit/", views.DDNSPolicyEditView.as_view(), name="ddnspolicy_edit"),
+        path("ddns-policies/<int:pk>/delete/", views.DDNSPolicyDeleteView.as_view(), name="ddnspolicy_delete"),
+        path(
+            "ddns-policies/<int:pk>/changelog/",
+            ObjectChangeLogView.as_view(),
+            name="ddnspolicy_changelog",
+            kwargs={"model": models.DDNSPolicy},
+        ),
+        path(
+            "ddns-policies/<int:pk>/servers/",
+            views.DDNSPolicyServersView.as_view(),
+            name="ddnspolicy_servers",
+        ),
+        path(
+            "ddns-policies/<int:pk>/subnets/",
+            views.DDNSPolicySubnetsView.as_view(),
+            name="ddnspolicy_subnets",
+        ),
+        path(
+            "ddns-policies/<int:pk>/client-classes/",
+            views.DDNSPolicyClientClassesView.as_view(),
+            name="ddnspolicy_clientclasses",
+        ),
+    ]

--- a/netbox_dhcp_kea_plugin/urls.py
+++ b/netbox_dhcp_kea_plugin/urls.py
@@ -337,6 +337,7 @@ if get_plugin_config("netbox_dhcp_kea_plugin", "enable_ddns"):
         path("ddns-domains/", views.DDNSDomainListView.as_view(), name="ddnsdomain_list"),
         path("ddns-domains/add/", views.DDNSDomainEditView.as_view(), name="ddnsdomain_add"),
         path("ddns-domains/import/", views.DDNSDomainImportView.as_view(), name="ddnsdomain_bulk_import"),
+        path("ddns-domains/edit/", views.DDNSDomainBulkEditView.as_view(), name="ddnsdomain_bulk_edit"),
         path("ddns-domains/delete/", views.DDNSDomainBulkDeleteView.as_view(), name="ddnsdomain_bulk_delete"),
         path("ddns-domains/<int:pk>/", views.DDNSDomainView.as_view(), name="ddnsdomain"),
         path("ddns-domains/<int:pk>/edit/", views.DDNSDomainEditView.as_view(), name="ddnsdomain_edit"),

--- a/netbox_dhcp_kea_plugin/views.py
+++ b/netbox_dhcp_kea_plugin/views.py
@@ -372,6 +372,7 @@ class DHCPServerView(generic.ObjectView):
             "unreachable_subnets": unreachable_subnets,
             "unreachable_pools": unreachable_pools,
             "enable_stork": get_plugin_config("netbox_dhcp_kea_plugin", "enable_stork"),
+            "enable_ddns": get_plugin_config("netbox_dhcp_kea_plugin", "enable_ddns"),
         }
 
 
@@ -1144,4 +1145,269 @@ class StorkAgentGroupConfigView(generic.ObjectView):
                 "tab": self.tab,
                 "env_content": env_content,
             },
+        )
+
+
+# --- TSIGKey Views ---
+
+
+class TSIGKeyView(generic.ObjectView):
+    queryset = models.TSIGKey.objects.all()
+
+    def get_extra_context(self, request, instance):
+        return {
+            "can_view_secret": request.user.has_perm("netbox_dhcp_kea_plugin.view_secret_tsigkey"),
+        }
+
+
+class TSIGKeyListView(generic.ObjectListView):
+    queryset = models.TSIGKey.objects.all()
+    table = tables.TSIGKeyTable
+    filterset = filtersets.TSIGKeyFilterSet
+    filterset_form = forms.TSIGKeyFilterForm
+
+
+class TSIGKeyEditView(generic.ObjectEditView):
+    queryset = models.TSIGKey.objects.all()
+    form = forms.TSIGKeyForm
+
+
+class TSIGKeyDeleteView(generic.ObjectDeleteView):
+    queryset = models.TSIGKey.objects.all()
+
+
+class TSIGKeyBulkDeleteView(generic.BulkDeleteView):
+    queryset = models.TSIGKey.objects.all()
+    filterset = filtersets.TSIGKeyFilterSet
+    table = tables.TSIGKeyTable
+
+
+class TSIGKeyImportView(generic.BulkImportView):
+    queryset = models.TSIGKey.objects.all()
+    model_form = forms.TSIGKeyImportForm
+
+
+# --- D2Daemon Views ---
+
+
+class D2DaemonView(generic.ObjectView):
+    queryset = models.D2Daemon.objects.select_related("ip_address").prefetch_related("domains")
+
+
+class D2DaemonListView(generic.ObjectListView):
+    queryset = models.D2Daemon.objects.annotate(
+        domains_count=Count("domains", distinct=True),
+    )
+    table = tables.D2DaemonTable
+    filterset = filtersets.D2DaemonFilterSet
+    filterset_form = forms.D2DaemonFilterForm
+
+
+class D2DaemonEditView(generic.ObjectEditView):
+    queryset = models.D2Daemon.objects.all()
+    form = forms.D2DaemonForm
+
+
+class D2DaemonDeleteView(generic.ObjectDeleteView):
+    queryset = models.D2Daemon.objects.all()
+
+
+class D2DaemonBulkDeleteView(generic.BulkDeleteView):
+    queryset = models.D2Daemon.objects.all()
+    filterset = filtersets.D2DaemonFilterSet
+    table = tables.D2DaemonTable
+
+
+class D2DaemonImportView(generic.BulkImportView):
+    queryset = models.D2Daemon.objects.all()
+    model_form = forms.D2DaemonImportForm
+
+
+def get_d2daemon_domains_count(obj):
+    return obj.domains.count()
+
+
+@register_model_view(models.D2Daemon, name="domains", path="domains")
+class D2DaemonDomainsView(generic.ObjectView):
+    queryset = models.D2Daemon.objects.all()
+    template_name = "netbox_dhcp_kea_plugin/d2daemon_domains.html"
+    tab = ViewTab(
+        label="Domains",
+        badge=get_d2daemon_domains_count,
+        permission="netbox_dhcp_kea_plugin.view_d2daemon",
+    )
+
+    def get(self, request, pk):
+        daemon = self.get_object(pk=pk)
+        domains = daemon.domains.select_related("zone", "tsig_key").prefetch_related("zone__nameservers")
+        return render(
+            request,
+            self.template_name,
+            {"object": daemon, "domains": domains, "tab": self.tab},
+        )
+
+
+@register_model_view(models.D2Daemon, name="config", path="config")
+class D2DaemonConfigView(generic.ObjectView):
+    queryset = models.D2Daemon.objects.all()
+    template_name = "netbox_dhcp_kea_plugin/d2daemon_config.html"
+    tab = ViewTab(
+        label="Configuration",
+        permission="netbox_dhcp_kea_plugin.view_d2daemon",
+    )
+
+    def get(self, request, pk):
+        daemon = self.get_object(pk=pk)
+        config = daemon.to_kea_dict()
+        return render(
+            request,
+            self.template_name,
+            {
+                "object": daemon,
+                "tab": self.tab,
+                "config_json": json.dumps(config, indent=2),
+            },
+        )
+
+
+# --- DDNSDomain Views ---
+
+
+class DDNSDomainView(generic.ObjectView):
+    queryset = models.DDNSDomain.objects.select_related("d2_daemon", "zone", "tsig_key").prefetch_related(
+        "zone__nameservers"
+    )
+
+
+class DDNSDomainListView(generic.ObjectListView):
+    queryset = models.DDNSDomain.objects.all()
+    table = tables.DDNSDomainTable
+    filterset = filtersets.DDNSDomainFilterSet
+    filterset_form = forms.DDNSDomainFilterForm
+
+
+class DDNSDomainEditView(generic.ObjectEditView):
+    queryset = models.DDNSDomain.objects.all()
+    form = forms.DDNSDomainForm
+
+
+class DDNSDomainDeleteView(generic.ObjectDeleteView):
+    queryset = models.DDNSDomain.objects.all()
+
+
+class DDNSDomainBulkDeleteView(generic.BulkDeleteView):
+    queryset = models.DDNSDomain.objects.all()
+    filterset = filtersets.DDNSDomainFilterSet
+    table = tables.DDNSDomainTable
+
+
+class DDNSDomainImportView(generic.BulkImportView):
+    queryset = models.DDNSDomain.objects.all()
+    model_form = forms.DDNSDomainImportForm
+
+
+# --- DDNSPolicy Views ---
+
+
+class DDNSPolicyView(generic.ObjectView):
+    queryset = models.DDNSPolicy.objects.prefetch_related("servers", "subnets", "client_classes")
+
+
+class DDNSPolicyListView(generic.ObjectListView):
+    queryset = models.DDNSPolicy.objects.annotate(
+        servers_count=Count("servers", distinct=True),
+        subnets_count=Count("subnets", distinct=True),
+        client_classes_count=Count("client_classes", distinct=True),
+    )
+    table = tables.DDNSPolicyTable
+    filterset = filtersets.DDNSPolicyFilterSet
+    filterset_form = forms.DDNSPolicyFilterForm
+
+
+class DDNSPolicyEditView(generic.ObjectEditView):
+    queryset = models.DDNSPolicy.objects.all()
+    form = forms.DDNSPolicyForm
+
+
+class DDNSPolicyDeleteView(generic.ObjectDeleteView):
+    queryset = models.DDNSPolicy.objects.all()
+
+
+class DDNSPolicyBulkDeleteView(generic.BulkDeleteView):
+    queryset = models.DDNSPolicy.objects.all()
+    filterset = filtersets.DDNSPolicyFilterSet
+    table = tables.DDNSPolicyTable
+
+
+class DDNSPolicyImportView(generic.BulkImportView):
+    queryset = models.DDNSPolicy.objects.all()
+    model_form = forms.DDNSPolicyImportForm
+
+
+def get_ddnspolicy_servers_count(obj):
+    return obj.servers.count()
+
+
+def get_ddnspolicy_subnets_count(obj):
+    return obj.subnets.count()
+
+
+def get_ddnspolicy_client_classes_count(obj):
+    return obj.client_classes.count()
+
+
+@register_model_view(models.DDNSPolicy, name="servers", path="servers")
+class DDNSPolicyServersView(generic.ObjectView):
+    queryset = models.DDNSPolicy.objects.all()
+    template_name = "netbox_dhcp_kea_plugin/ddnspolicy_servers.html"
+    tab = ViewTab(
+        label="Servers",
+        badge=get_ddnspolicy_servers_count,
+        permission="netbox_dhcp_kea_plugin.view_ddnspolicy",
+    )
+
+    def get(self, request, pk):
+        policy = self.get_object(pk=pk)
+        return render(
+            request,
+            self.template_name,
+            {"object": policy, "servers": policy.servers.all(), "tab": self.tab},
+        )
+
+
+@register_model_view(models.DDNSPolicy, name="subnets", path="subnets")
+class DDNSPolicySubnetsView(generic.ObjectView):
+    queryset = models.DDNSPolicy.objects.all()
+    template_name = "netbox_dhcp_kea_plugin/ddnspolicy_subnets.html"
+    tab = ViewTab(
+        label="Subnets",
+        badge=get_ddnspolicy_subnets_count,
+        permission="netbox_dhcp_kea_plugin.view_ddnspolicy",
+    )
+
+    def get(self, request, pk):
+        policy = self.get_object(pk=pk)
+        return render(
+            request,
+            self.template_name,
+            {"object": policy, "subnets": policy.subnets.all(), "tab": self.tab},
+        )
+
+
+@register_model_view(models.DDNSPolicy, name="clientclasses", path="client-classes")
+class DDNSPolicyClientClassesView(generic.ObjectView):
+    queryset = models.DDNSPolicy.objects.all()
+    template_name = "netbox_dhcp_kea_plugin/ddnspolicy_clientclasses.html"
+    tab = ViewTab(
+        label="Client Classes",
+        badge=get_ddnspolicy_client_classes_count,
+        permission="netbox_dhcp_kea_plugin.view_ddnspolicy",
+    )
+
+    def get(self, request, pk):
+        policy = self.get_object(pk=pk)
+        return render(
+            request,
+            self.template_name,
+            {"object": policy, "client_classes": policy.client_classes.all(), "tab": self.tab},
         )

--- a/netbox_dhcp_kea_plugin/views.py
+++ b/netbox_dhcp_kea_plugin/views.py
@@ -518,9 +518,12 @@ class ClientClassView(generic.ObjectView):
     queryset = models.ClientClass.objects.prefetch_related("option_data")
 
     def get_extra_context(self, request, instance):
+        from netbox.plugins.utils import get_plugin_config
+
         return {
             "kea_config_hex": instance.to_kea_json(ascii_format=False, indent=4),
             "kea_config_ascii": instance.to_kea_json(ascii_format=True, indent=4),
+            "enable_ddns": get_plugin_config("netbox_dhcp_kea_plugin", "enable_ddns"),
         }
 
 
@@ -697,6 +700,8 @@ class SubnetView(generic.ObjectView):
     def get_extra_context(self, request, instance):
         import json
 
+        from netbox.plugins.utils import get_plugin_config
+
         # Find evaluate_additional_classes entries that don't have only_in_additional_list set.
         # These classes are already evaluated globally by KEA, so listing them in
         # evaluate-additional-classes is redundant.
@@ -706,6 +711,7 @@ class SubnetView(generic.ObjectView):
             "kea_config": json.dumps(instance.to_kea_dict(), indent=2),
             "pool_count": instance.subnet_pools.count(),
             "redundant_eval_classes": redundant_eval_classes,
+            "enable_ddns": get_plugin_config("netbox_dhcp_kea_plugin", "enable_ddns"),
         }
 
 
@@ -773,6 +779,13 @@ class SubnetImportView(generic.BulkImportView):
 # DHCPHARelationship Views
 class DHCPHARelationshipView(generic.ObjectView):
     queryset = models.DHCPHARelationship.objects.prefetch_related("servers")
+
+    def get_extra_context(self, request, instance):
+        from netbox.plugins.utils import get_plugin_config
+
+        return {
+            "enable_ddns": get_plugin_config("netbox_dhcp_kea_plugin", "enable_ddns"),
+        }
 
 
 class DHCPHARelationshipListView(generic.ObjectListView):

--- a/netbox_dhcp_kea_plugin/views.py
+++ b/netbox_dhcp_kea_plugin/views.py
@@ -1295,6 +1295,13 @@ class DDNSDomainDeleteView(generic.ObjectDeleteView):
     queryset = models.DDNSDomain.objects.all()
 
 
+class DDNSDomainBulkEditView(generic.BulkEditView):
+    queryset = models.DDNSDomain.objects.all()
+    filterset = filtersets.DDNSDomainFilterSet
+    table = tables.DDNSDomainTable
+    form = forms.DDNSDomainBulkEditForm
+
+
 class DDNSDomainBulkDeleteView(generic.BulkDeleteView):
     queryset = models.DDNSDomain.objects.all()
     filterset = filtersets.DDNSDomainFilterSet

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "netbox-dhcp-kea-plugin"
-version = "0.7.3"
+version = "0.8.0"
 authors = [
     {name = "Łukasz Polański", email = "wookasz@gmail.com"},
 ]

--- a/tests/test_ddns_api.py
+++ b/tests/test_ddns_api.py
@@ -1,0 +1,128 @@
+"""DDNS API surface — CRUD, perm-gated TSIG secret, per-daemon kea-config."""
+
+import base64
+
+import pytest
+from django.contrib.auth import get_user_model
+from django.urls import reverse
+from netbox.plugins.utils import get_plugin_config
+from rest_framework.test import APIClient
+
+
+pytestmark = [
+    pytest.mark.django_db,
+    pytest.mark.skipif(
+        not get_plugin_config("netbox_dhcp_kea_plugin", "enable_ddns"),
+        reason="enable_ddns plugin flag is off — DDNS API routes not registered",
+    ),
+]
+
+
+def _grant(user, *actions):
+    """Attach an ObjectPermission for TSIGKey to ``user`` with the given actions."""
+    from core.models import ObjectType
+    from users.models import ObjectPermission
+
+    from netbox_dhcp_kea_plugin.models import TSIGKey
+
+    op = ObjectPermission.objects.create(name=f"perm-{user.pk}-{'-'.join(actions)}", actions=list(actions))
+    op.users.add(user)
+    op.object_types.add(ObjectType.objects.get_for_model(TSIGKey))
+    return op
+
+
+@pytest.fixture
+def admin_user(db):
+    return get_user_model().objects.create_superuser(
+        username="admin", email="admin@example.com", password="x"
+    )
+
+
+@pytest.fixture
+def viewer_user(db):
+    user = get_user_model().objects.create_user(username="viewer", password="x")
+    _grant(user, "view")
+    return user
+
+
+@pytest.fixture
+def secret_viewer_user(db):
+    user = get_user_model().objects.create_user(username="secretviewer", password="x")
+    _grant(user, "view", "view_secret")
+    return user
+
+
+@pytest.fixture
+def api_client(admin_user):
+    client = APIClient()
+    client.force_authenticate(user=admin_user)
+    return client
+
+
+@pytest.fixture
+def tsig_key(db):
+    from netbox_dhcp_kea_plugin.models import TSIGKey
+
+    return TSIGKey.objects.create(
+        name="api-test.",
+        algorithm="HMAC-SHA256",
+        secret_backend="plaintext",
+        secret_plaintext=base64.b64encode(b"api-secret").decode(),
+    )
+
+
+@pytest.fixture
+def d2_daemon(db):
+    from ipam.models import IPAddress
+
+    from netbox_dhcp_kea_plugin.models import D2Daemon
+
+    ip = IPAddress.objects.create(address="10.0.2.50/24")
+    return D2Daemon.objects.create(name="d2-api", ip_address=ip)
+
+
+def test_tsig_key_serializer_hides_secret_without_perm(tsig_key, viewer_user):
+    client = APIClient()
+    client.force_authenticate(user=viewer_user)
+    url = reverse("plugins-api:netbox_dhcp_kea_plugin-api:tsigkey-detail", args=[tsig_key.pk])
+    resp = client.get(url)
+    assert resp.status_code == 200
+    assert "secret_plaintext" not in resp.data
+
+
+def test_tsig_key_serializer_shows_secret_with_perm(tsig_key, secret_viewer_user):
+    client = APIClient()
+    client.force_authenticate(user=secret_viewer_user)
+    url = reverse("plugins-api:netbox_dhcp_kea_plugin-api:tsigkey-detail", args=[tsig_key.pk])
+    resp = client.get(url)
+    assert resp.status_code == 200
+    assert resp.data.get("secret_plaintext") == tsig_key.secret_plaintext
+
+
+def test_d2daemon_kea_config_endpoint(api_client, d2_daemon):
+    url = reverse(
+        "plugins-api:netbox_dhcp_kea_plugin-api:d2daemon-kea-config",
+        args=[d2_daemon.pk],
+    )
+    resp = api_client.get(url)
+    assert resp.status_code == 200
+    assert "DhcpDdns" in resp.data
+    assert resp.data["DhcpDdns"]["port"] == d2_daemon.port
+
+
+def test_ddns_policy_create(api_client):
+    url = reverse("plugins-api:netbox_dhcp_kea_plugin-api:ddnspolicy-list")
+    resp = api_client.post(
+        url,
+        {
+            "name": "p1",
+            "description": "",
+            "ddns_send_updates": True,
+            "ddns_qualifying_suffix": "lab.example.com",
+        },
+        format="json",
+    )
+    assert resp.status_code == 201, resp.data
+    assert resp.data["ddns_qualifying_suffix"] == "lab.example.com"
+
+

--- a/tests/test_ddns_config_generation.py
+++ b/tests/test_ddns_config_generation.py
@@ -1,0 +1,124 @@
+"""Kea config emission for DDNS — server, subnet, and class layers.
+
+Verifies that DDNSPolicy.to_kea_overrides() output is spread verbatim into the
+correct JSON level and that *no* Python-side merging happens between layers
+(Kea handles inheritance at packet-processing time).
+"""
+
+import pytest
+
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.fixture
+def policy_server(db):
+    from netbox_dhcp_kea_plugin.models import DDNSPolicy
+
+    return DDNSPolicy.objects.create(
+        name="server-policy",
+        ddns_send_updates=True,
+        ddns_qualifying_suffix="srv.example.com",
+    )
+
+
+@pytest.fixture
+def policy_subnet(db):
+    from netbox_dhcp_kea_plugin.models import DDNSPolicy
+
+    return DDNSPolicy.objects.create(
+        name="subnet-policy",
+        ddns_qualifying_suffix="sub.example.com",
+        ddns_ttl=600,
+    )
+
+
+@pytest.fixture
+def policy_class(db):
+    from netbox_dhcp_kea_plugin.models import DDNSPolicy
+
+    return DDNSPolicy.objects.create(
+        name="class-policy",
+        ddns_generated_prefix="myhost",
+    )
+
+
+def test_server_policy_emits_at_dhcp4_top_level(dhcp_server, policy_server):
+    dhcp_server.ddns_policy = policy_server
+    dhcp_server.save()
+
+    dhcp4 = dhcp_server.to_kea_dict()["Dhcp4"]
+    assert dhcp4["ddns-send-updates"] is True
+    assert dhcp4["ddns-qualifying-suffix"] == "srv.example.com"
+
+
+def test_subnet_policy_emits_inside_subnet_dict(subnet_factory, policy_subnet):
+    subnet = subnet_factory()
+    subnet.ddns_policy = policy_subnet
+    subnet.save()
+
+    server = subnet.server
+    dhcp4 = server.to_kea_dict()["Dhcp4"]
+    subnets = dhcp4.get("subnet4", [])
+    assert subnets, "expected at least one subnet emitted"
+    target = next((s for s in subnets if s.get("id") == subnet.id or s.get("subnet")), subnets[0])
+    assert target.get("ddns-qualifying-suffix") == "sub.example.com"
+    assert target.get("ddns-ttl") == 600
+
+
+def test_subnet_policy_does_not_leak_into_server_top_level(
+    subnet_factory, policy_subnet
+):
+    subnet = subnet_factory()
+    subnet.ddns_policy = policy_subnet
+    subnet.save()
+
+    dhcp4 = subnet.server.to_kea_dict()["Dhcp4"]
+    # Subnet-level override must not appear at the top level.
+    assert dhcp4.get("ddns-qualifying-suffix") != "sub.example.com"
+
+
+def test_no_python_side_merging_between_server_and_subnet(
+    subnet_factory, policy_server, policy_subnet
+):
+    subnet = subnet_factory()
+    server = subnet.server
+    server.ddns_policy = policy_server
+    server.save()
+    subnet.ddns_policy = policy_subnet
+    subnet.save()
+
+    dhcp4 = server.to_kea_dict()["Dhcp4"]
+    # Top level keeps server policy verbatim
+    assert dhcp4["ddns-qualifying-suffix"] == "srv.example.com"
+    assert dhcp4["ddns-send-updates"] is True
+
+    target = dhcp4["subnet4"][0]
+    # Subnet level keeps its own policy verbatim, NOT a merge of server+subnet.
+    assert target["ddns-qualifying-suffix"] == "sub.example.com"
+    assert "ddns-send-updates" not in target
+
+
+def test_class_policy_emits_inside_client_class_dict(
+    dhcp_server, client_class, policy_class
+):
+    client_class.ddns_policy = policy_class
+    client_class.save()
+    client_class.servers.add(dhcp_server)
+
+    dhcp4 = dhcp_server.to_kea_dict()["Dhcp4"]
+    classes = dhcp4.get("client-classes", [])
+    assert classes
+    target = next(c for c in classes if c["name"] == client_class.name)
+    assert target.get("ddns-generated-prefix") == "myhost"
+
+
+def test_no_ddns_keys_when_no_policy_attached(dhcp_server):
+    dhcp4 = dhcp_server.to_kea_dict()["Dhcp4"]
+    for key in dhcp4:
+        assert not key.startswith("ddns-"), f"unexpected DDNS key {key} at top level"
+
+
+def test_dhcp_ddns_block_absent_without_connection(dhcp_server):
+    dhcp4 = dhcp_server.to_kea_dict()["Dhcp4"]
+    assert "dhcp-ddns" not in dhcp4

--- a/tests/test_ddns_gating.py
+++ b/tests/test_ddns_gating.py
@@ -1,0 +1,91 @@
+"""enable_ddns feature flag gating.
+
+Verifies the startup check for ``enable_ddns=True`` without netbox_dns and
+that menus / API routes / URL patterns are absent when the flag is off.
+
+The check itself is unit-tested by directly invoking the validator with a
+mocked PLUGINS_CONFIG; we don't actually toggle Django settings between
+tests because most of the conditional wiring is done at import time.
+"""
+
+import pytest
+from django.core.exceptions import ImproperlyConfigured
+
+
+pytestmark = pytest.mark.django_db
+
+
+def test_validate_ddns_dependencies_no_op_when_flag_off(monkeypatch):
+    from netbox_dhcp_kea_plugin import DHCPKEAConfig
+
+    monkeypatch.setattr(
+        "django.conf.settings.PLUGINS_CONFIG",
+        {"netbox_dhcp_kea_plugin": {"enable_ddns": False}},
+        raising=False,
+    )
+    DHCPKEAConfig._validate_ddns_dependencies()
+
+
+def test_validate_ddns_dependencies_raises_without_netbox_dns_flag(monkeypatch):
+    from netbox_dhcp_kea_plugin import DHCPKEAConfig
+
+    monkeypatch.setattr(
+        "django.conf.settings.PLUGINS_CONFIG",
+        {
+            "netbox_dhcp_kea_plugin": {
+                "enable_ddns": True,
+                "enable_netbox_dns": False,
+            }
+        },
+        raising=False,
+    )
+    with pytest.raises(ImproperlyConfigured) as exc:
+        DHCPKEAConfig._validate_ddns_dependencies()
+    assert "enable_netbox_dns" in str(exc.value)
+
+
+def test_validate_ddns_dependencies_raises_when_netbox_dns_missing(monkeypatch):
+    from netbox_dhcp_kea_plugin import DHCPKEAConfig
+
+    monkeypatch.setattr(
+        "django.conf.settings.PLUGINS_CONFIG",
+        {
+            "netbox_dhcp_kea_plugin": {
+                "enable_ddns": True,
+                "enable_netbox_dns": True,
+            }
+        },
+        raising=False,
+    )
+
+    import builtins
+
+    real_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name == "netbox_dns":
+            raise ImportError("simulated missing netbox_dns")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+    with pytest.raises(ImproperlyConfigured) as exc:
+        DHCPKEAConfig._validate_ddns_dependencies()
+    assert "netbox_dns" in str(exc.value)
+
+
+def test_secret_backend_registry_has_plaintext():
+    from netbox_dhcp_kea_plugin.secret_backends import TSIG_SECRET_BACKENDS
+
+    assert "plaintext" in TSIG_SECRET_BACKENDS
+
+
+def test_secret_backend_unknown_raises():
+    from netbox_dhcp_kea_plugin.models import TSIGKey
+    from netbox_dhcp_kea_plugin.secret_backends import (
+        TSIGSecretBackendError,
+        resolve_secret,
+    )
+
+    key = TSIGKey(name="bogus.", algorithm="HMAC-SHA256", secret_backend="vault")
+    with pytest.raises(TSIGSecretBackendError):
+        resolve_secret(key)

--- a/tests/test_ddns_ha_precedence.py
+++ b/tests/test_ddns_ha_precedence.py
@@ -1,0 +1,134 @@
+"""HA-relationship precedence rules for the D2 daemon and DDNS sender block.
+
+When a DHCPServer belongs to an HA relationship and that relationship has its
+own ``d2_daemon`` set, the relationship's DDNS block (d2_daemon +
+ddns_enable_updates + ddns_sender_ip + ddns_sender_port) wins and the
+server's own values are ignored. Removing the relationship reverts the server
+to its own values.
+"""
+
+import pytest
+
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.fixture
+def d2_a(db):
+    from ipam.models import IPAddress
+
+    from netbox_dhcp_kea_plugin.models import D2Daemon
+
+    ip = IPAddress.objects.create(address="10.0.1.50/24")
+    return D2Daemon.objects.create(name="d2-a", ip_address=ip)
+
+
+@pytest.fixture
+def d2_b(db):
+    from ipam.models import IPAddress
+
+    from netbox_dhcp_kea_plugin.models import D2Daemon
+
+    ip = IPAddress.objects.create(address="10.0.1.51/24")
+    return D2Daemon.objects.create(name="d2-b", ip_address=ip)
+
+
+@pytest.fixture
+def ha_relationship(db):
+    from netbox_dhcp_kea_plugin.models import DHCPHARelationship
+
+    return DHCPHARelationship.objects.create(
+        name="ha-1",
+        mode="hot-standby",
+    )
+
+
+def _eff_pk(server):
+    eff = server.effective_d2_daemon
+    return eff.pk if eff is not None else None
+
+
+def test_effective_returns_own_when_no_ha(dhcp_server, d2_a):
+    dhcp_server.d2_daemon = d2_a
+    dhcp_server.save()
+    assert _eff_pk(dhcp_server) == d2_a.pk
+
+
+def test_effective_returns_ha_d2_when_relationship_set(
+    dhcp_server_factory, ha_relationship, d2_a, d2_b
+):
+    server = dhcp_server_factory(ha_relationship=ha_relationship, ha_role="primary")
+    server.d2_daemon = d2_a
+    server.save()
+    ha_relationship.d2_daemon = d2_b
+    ha_relationship.save()
+    server.refresh_from_db()
+    assert _eff_pk(server) == d2_b.pk
+
+
+def test_effective_falls_back_to_own_when_ha_has_no_d2(
+    dhcp_server_factory, ha_relationship, d2_a
+):
+    server = dhcp_server_factory(ha_relationship=ha_relationship, ha_role="primary")
+    server.d2_daemon = d2_a
+    server.save()
+    assert ha_relationship.d2_daemon_id is None
+    assert _eff_pk(server) == d2_a.pk
+
+
+def test_effective_toggles_when_server_added_to_ha(
+    dhcp_server, ha_relationship, d2_a, d2_b
+):
+    dhcp_server.d2_daemon = d2_a
+    dhcp_server.save()
+    assert _eff_pk(dhcp_server) == d2_a.pk
+
+    ha_relationship.d2_daemon = d2_b
+    ha_relationship.save()
+    dhcp_server.ha_relationship = ha_relationship
+    dhcp_server.ha_role = "primary"
+    dhcp_server.save()
+    dhcp_server.refresh_from_db()
+    assert _eff_pk(dhcp_server) == d2_b.pk
+
+
+def test_effective_reverts_when_server_removed_from_ha(
+    dhcp_server, ha_relationship, d2_a, d2_b
+):
+    ha_relationship.d2_daemon = d2_b
+    ha_relationship.save()
+    dhcp_server.d2_daemon = d2_a
+    dhcp_server.ha_relationship = ha_relationship
+    dhcp_server.ha_role = "primary"
+    dhcp_server.save()
+    assert _eff_pk(dhcp_server) == d2_b.pk
+
+    dhcp_server.ha_relationship = None
+    dhcp_server.ha_role = ""
+    dhcp_server.save()
+    assert _eff_pk(dhcp_server) == d2_a.pk
+
+
+def test_dhcpserver_to_kea_dict_uses_ha_d2_block(
+    dhcp_server_factory, ha_relationship, d2_a, d2_b
+):
+    server = dhcp_server_factory(ha_relationship=ha_relationship, ha_role="primary")
+    server.d2_daemon = d2_a
+    server.ddns_sender_ip = "192.0.2.10"
+    server.save()
+    ha_relationship.d2_daemon = d2_b
+    ha_relationship.ddns_enable_updates = False
+    ha_relationship.ddns_sender_ip = "192.0.2.99"
+    ha_relationship.ddns_sender_port = 5555
+    ha_relationship.save()
+    server.refresh_from_db()
+
+    cfg = server.to_kea_dict()
+    dhcp4 = cfg.get("Dhcp4", {})
+    block = dhcp4.get("dhcp-ddns")
+    assert block is not None
+    assert block["server-ip"] == str(d2_b.ip_address.address.ip)
+    assert block["server-port"] == d2_b.port
+    assert block["enable-updates"] is False
+    assert block["sender-ip"] == "192.0.2.99"
+    assert block["sender-port"] == 5555

--- a/tests/test_ddns_ha_precedence.py
+++ b/tests/test_ddns_ha_precedence.py
@@ -1,10 +1,11 @@
 """HA-relationship precedence rules for the D2 daemon and DDNS sender block.
 
 When a DHCPServer belongs to an HA relationship and that relationship has its
-own ``d2_daemon`` set, the relationship's DDNS block (d2_daemon +
-ddns_enable_updates + ddns_sender_ip + ddns_sender_port) wins and the
-server's own values are ignored. Removing the relationship reverts the server
-to its own values.
+own ``d2_daemon`` set, the relationship's d2_daemon and ddns_enable_updates
+win and the server's own values for those two are ignored. Sender IP/port are
+per-server (the local source endpoint) and are not overridden by the HA
+relationship. Removing the relationship reverts the server to its own
+d2_daemon/enable_updates values.
 """
 
 import pytest
@@ -115,11 +116,10 @@ def test_dhcpserver_to_kea_dict_uses_ha_d2_block(
     server = dhcp_server_factory(ha_relationship=ha_relationship, ha_role="primary")
     server.d2_daemon = d2_a
     server.ddns_sender_ip = "192.0.2.10"
+    server.ddns_sender_port = 5555
     server.save()
     ha_relationship.d2_daemon = d2_b
     ha_relationship.ddns_enable_updates = False
-    ha_relationship.ddns_sender_ip = "192.0.2.99"
-    ha_relationship.ddns_sender_port = 5555
     ha_relationship.save()
     server.refresh_from_db()
 
@@ -127,8 +127,55 @@ def test_dhcpserver_to_kea_dict_uses_ha_d2_block(
     dhcp4 = cfg.get("Dhcp4", {})
     block = dhcp4.get("dhcp-ddns")
     assert block is not None
+    # HA relationship wins for d2_daemon target + enable_updates flag
     assert block["server-ip"] == str(d2_b.ip_address.address.ip)
     assert block["server-port"] == d2_b.port
     assert block["enable-updates"] is False
-    assert block["sender-ip"] == "192.0.2.99"
+    # Sender stays per-server — never overridden by HA
+    assert block["sender-ip"] == "192.0.2.10"
     assert block["sender-port"] == 5555
+
+
+def test_effective_ddns_policy_returns_ha_when_set(
+    dhcp_server_factory, ha_relationship
+):
+    from netbox_dhcp_kea_plugin.models import DDNSPolicy
+
+    own = DDNSPolicy.objects.create(name="own", ddns_qualifying_suffix="own.example.com")
+    ha_pol = DDNSPolicy.objects.create(name="ha", ddns_qualifying_suffix="ha.example.com")
+    server = dhcp_server_factory(ha_relationship=ha_relationship, ha_role="primary")
+    server.ddns_policy = own
+    server.save()
+    ha_relationship.ddns_policy = ha_pol
+    ha_relationship.save()
+    server.refresh_from_db()
+    assert server.effective_ddns_policy.pk == ha_pol.pk
+
+
+def test_effective_ddns_policy_falls_back_to_own(dhcp_server_factory, ha_relationship):
+    from netbox_dhcp_kea_plugin.models import DDNSPolicy
+
+    own = DDNSPolicy.objects.create(name="own2", ddns_qualifying_suffix="own.example.com")
+    server = dhcp_server_factory(ha_relationship=ha_relationship, ha_role="primary")
+    server.ddns_policy = own
+    server.save()
+    assert ha_relationship.ddns_policy_id is None
+    assert server.effective_ddns_policy.pk == own.pk
+
+
+def test_dhcpserver_to_kea_dict_uses_ha_ddns_policy(
+    dhcp_server_factory, ha_relationship
+):
+    from netbox_dhcp_kea_plugin.models import DDNSPolicy
+
+    own = DDNSPolicy.objects.create(name="srv", ddns_qualifying_suffix="srv.example.com")
+    ha_pol = DDNSPolicy.objects.create(name="hap", ddns_qualifying_suffix="ha.example.com")
+    server = dhcp_server_factory(ha_relationship=ha_relationship, ha_role="primary")
+    server.ddns_policy = own
+    server.save()
+    ha_relationship.ddns_policy = ha_pol
+    ha_relationship.save()
+    server.refresh_from_db()
+
+    dhcp4 = server.to_kea_dict().get("Dhcp4", {})
+    assert dhcp4.get("ddns-qualifying-suffix") == "ha.example.com"

--- a/tests/test_ddns_ha_precedence.py
+++ b/tests/test_ddns_ha_precedence.py
@@ -21,7 +21,7 @@ def d2_a(db):
     from netbox_dhcp_kea_plugin.models import D2Daemon
 
     ip = IPAddress.objects.create(address="10.0.1.50/24")
-    return D2Daemon.objects.create(name="d2-a", ip_address=ip)
+    return D2Daemon.objects.create(name="d2-a", listener_mode="remote", ip_address=ip)
 
 
 @pytest.fixture
@@ -31,7 +31,7 @@ def d2_b(db):
     from netbox_dhcp_kea_plugin.models import D2Daemon
 
     ip = IPAddress.objects.create(address="10.0.1.51/24")
-    return D2Daemon.objects.create(name="d2-b", ip_address=ip)
+    return D2Daemon.objects.create(name="d2-b", listener_mode="remote", ip_address=ip)
 
 
 @pytest.fixture

--- a/tests/test_ddns_models.py
+++ b/tests/test_ddns_models.py
@@ -1,0 +1,344 @@
+"""Tests for the DDNS model layer.
+
+Covers TSIGKey validation, secret backend resolution, DDNSDomain direction
+derivation and clean(), and DDNSPolicy.to_kea_overrides() emission rules.
+"""
+
+import base64
+from decimal import Decimal
+
+import pytest
+from django.core.exceptions import ValidationError
+
+
+pytestmark = pytest.mark.django_db
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def d2_listener_ip(db):
+    from ipam.models import IPAddress
+
+    return IPAddress.objects.create(address="10.0.0.50/24")
+
+
+@pytest.fixture
+def d2_daemon(db, d2_listener_ip):
+    from netbox_dhcp_kea_plugin.models import D2Daemon
+
+    return D2Daemon.objects.create(
+        name="d2-primary",
+        ip_address=d2_listener_ip,
+        port=53001,
+    )
+
+
+@pytest.fixture
+def tsig_key(db):
+    from netbox_dhcp_kea_plugin.models import TSIGKey
+
+    return TSIGKey.objects.create(
+        name="d2.example.com.",
+        algorithm="HMAC-SHA256",
+        secret_backend="plaintext",
+        secret_plaintext=base64.b64encode(b"super-secret-bytes").decode(),
+    )
+
+
+@pytest.fixture
+def forward_zone(db):
+    from netbox_dns.models import View, Zone
+
+    view, _ = View.objects.get_or_create(name="default")
+    return Zone.objects.create(name="example.com", view=view, soa_mname_id=None) if False else _make_zone("example.com")
+
+
+@pytest.fixture
+def reverse_zone(db):
+    return _make_zone("1.168.192.in-addr.arpa")
+
+
+@pytest.fixture
+def name_server(db):
+    """A NameServer plus an A record so _resolve_nameserver_ips returns an IP."""
+    from netbox_dns.choices import RecordTypeChoices
+    from netbox_dns.models import NameServer, Record
+
+    ns = NameServer.objects.get_or_create(name="ns1.example.com")[0]
+    # Record needs a zone; reuse a dedicated zone for the NS A record.
+    ns_zone = _make_zone("example.com")
+    Record.objects.get_or_create(
+        zone=ns_zone,
+        name="ns1",
+        type=RecordTypeChoices.A,
+        value="192.0.2.53",
+    )
+    return ns
+
+
+def _make_zone(name):
+    """Create a netbox-dns Zone with whatever defaults the local install requires."""
+    from netbox_dns.models import NameServer, View, Zone
+
+    view, _ = View.objects.get_or_create(name="default")
+    soa = NameServer.objects.get_or_create(name="ns-soa.example.com")[0]
+    zone, _ = Zone.objects.get_or_create(
+        name=name,
+        view=view,
+        defaults={
+            "soa_mname": soa,
+            "soa_rname": "hostmaster.example.com",
+        },
+    )
+    return zone
+
+
+def _attach_ns_to_zone(zone, ns):
+    zone.nameservers.add(ns)
+
+
+# ---------------------------------------------------------------------------
+# TSIGKey
+# ---------------------------------------------------------------------------
+
+
+def test_tsig_key_clean_accepts_valid_base64():
+    from netbox_dhcp_kea_plugin.models import TSIGKey
+
+    key = TSIGKey(
+        name="ok.",
+        algorithm="HMAC-SHA256",
+        secret_backend="plaintext",
+        secret_plaintext=base64.b64encode(b"1234567890").decode(),
+    )
+    key.full_clean()
+
+
+def test_tsig_key_clean_rejects_non_base64():
+    from netbox_dhcp_kea_plugin.models import TSIGKey
+
+    key = TSIGKey(
+        name="bad.",
+        algorithm="HMAC-SHA256",
+        secret_backend="plaintext",
+        secret_plaintext="not!base64!!",
+    )
+    with pytest.raises(ValidationError) as exc:
+        key.full_clean()
+    assert "secret_plaintext" in exc.value.message_dict
+
+
+def test_tsig_key_clean_rejects_oversize_digest_bits():
+    from netbox_dhcp_kea_plugin.models import TSIGKey
+
+    key = TSIGKey(
+        name="oversize.",
+        algorithm="HMAC-SHA1",  # 160 bits max
+        secret_backend="plaintext",
+        secret_plaintext=base64.b64encode(b"x").decode(),
+        digest_bits=512,
+    )
+    with pytest.raises(ValidationError) as exc:
+        key.full_clean()
+    assert "digest_bits" in exc.value.message_dict
+
+
+def test_tsig_key_clean_requires_secret_for_plaintext_backend():
+    from netbox_dhcp_kea_plugin.models import TSIGKey
+
+    key = TSIGKey(
+        name="empty.",
+        algorithm="HMAC-SHA256",
+        secret_backend="plaintext",
+        secret_plaintext="",
+    )
+    with pytest.raises(ValidationError):
+        key.full_clean()
+
+
+def test_tsig_key_get_secret_plaintext(tsig_key):
+    assert tsig_key.get_secret() == tsig_key.secret_plaintext
+
+
+def test_tsig_key_to_kea_dict_includes_lower_algorithm(tsig_key):
+    d = tsig_key.to_kea_dict()
+    assert d["name"] == tsig_key.name
+    assert d["algorithm"] == "hmac-sha256"
+    assert d["secret"] == tsig_key.secret_plaintext
+
+
+def test_tsig_key_to_kea_dict_includes_digest_bits_when_set(db):
+    from netbox_dhcp_kea_plugin.models import TSIGKey
+
+    key = TSIGKey.objects.create(
+        name="trunc.",
+        algorithm="HMAC-SHA256",
+        digest_bits=128,
+        secret_backend="plaintext",
+        secret_plaintext=base64.b64encode(b"y").decode(),
+    )
+    assert key.to_kea_dict()["digest-bits"] == 128
+
+
+# ---------------------------------------------------------------------------
+# DDNSDomain
+# ---------------------------------------------------------------------------
+
+
+def test_ddnsdomain_is_reverse_for_in_addr_arpa(db, d2_daemon):
+    from netbox_dhcp_kea_plugin.models import DDNSDomain
+
+    zone = _make_zone("0.10.in-addr.arpa")
+    domain = DDNSDomain.objects.create(d2_daemon=d2_daemon, zone=zone)
+    assert domain.is_reverse is True
+
+
+def test_ddnsdomain_is_reverse_for_ip6_arpa(db, d2_daemon):
+    from netbox_dhcp_kea_plugin.models import DDNSDomain
+
+    zone = _make_zone("0.0.0.0.ip6.arpa")
+    domain = DDNSDomain.objects.create(d2_daemon=d2_daemon, zone=zone)
+    assert domain.is_reverse is True
+
+
+def test_ddnsdomain_is_forward_for_regular_zone(db, d2_daemon):
+    from netbox_dhcp_kea_plugin.models import DDNSDomain
+
+    zone = _make_zone("example.com")
+    domain = DDNSDomain.objects.create(d2_daemon=d2_daemon, zone=zone)
+    assert domain.is_reverse is False
+
+
+def test_ddnsdomain_to_kea_dict_omits_key_name_when_no_tsig(db, d2_daemon, name_server):
+    from netbox_dhcp_kea_plugin.models import DDNSDomain
+
+    zone = _make_zone("nokey.example.com")
+    _attach_ns_to_zone(zone, name_server)
+    domain = DDNSDomain.objects.create(d2_daemon=d2_daemon, zone=zone)
+    d = domain.to_kea_dict()
+    assert "key-name" not in d
+    assert d["name"].endswith(".")
+
+
+def test_ddnsdomain_to_kea_dict_includes_key_name_when_tsig_set(
+    db, d2_daemon, tsig_key, name_server
+):
+    from netbox_dhcp_kea_plugin.models import DDNSDomain
+
+    zone = _make_zone("withkey.example.com")
+    _attach_ns_to_zone(zone, name_server)
+    domain = DDNSDomain.objects.create(d2_daemon=d2_daemon, zone=zone, tsig_key=tsig_key)
+    assert domain.to_kea_dict()["key-name"] == tsig_key.name
+
+
+def test_ddnsdomain_to_kea_dict_resolves_nameserver_ips(db, d2_daemon, name_server):
+    from netbox_dhcp_kea_plugin.models import DDNSDomain
+
+    zone = _make_zone("ips.example.com")
+    _attach_ns_to_zone(zone, name_server)
+    domain = DDNSDomain.objects.create(d2_daemon=d2_daemon, zone=zone)
+    out = domain.to_kea_dict()
+    assert out["dns-servers"] == [{"ip-address": "192.0.2.53", "port": 53}]
+
+
+# ---------------------------------------------------------------------------
+# DDNSPolicy
+# ---------------------------------------------------------------------------
+
+
+def test_ddnspolicy_to_kea_overrides_returns_only_set_keys(db):
+    from netbox_dhcp_kea_plugin.models import DDNSPolicy
+
+    policy = DDNSPolicy.objects.create(
+        name="partial",
+        ddns_send_updates=True,
+        ddns_qualifying_suffix="lab.example.com",
+    )
+    overrides = policy.to_kea_overrides()
+    assert overrides == {
+        "ddns-send-updates": True,
+        "ddns-qualifying-suffix": "lab.example.com",
+    }
+
+
+def test_ddnspolicy_to_kea_overrides_kebab_cases_field_names(db):
+    from netbox_dhcp_kea_plugin.models import DDNSPolicy
+
+    policy = DDNSPolicy.objects.create(
+        name="kebab",
+        ddns_override_no_update=False,
+        ddns_override_client_update=True,
+        hostname_char_set="[^a-zA-Z0-9]",
+        hostname_char_replacement="-",
+    )
+    overrides = policy.to_kea_overrides()
+    assert "ddns-override-no-update" in overrides
+    assert "ddns-override-client-update" in overrides
+    assert "hostname-char-set" in overrides
+    assert "hostname-char-replacement" in overrides
+    assert all("_" not in k for k in overrides)
+
+
+def test_ddnspolicy_to_kea_overrides_decimal_emitted_as_float(db):
+    from netbox_dhcp_kea_plugin.models import DDNSPolicy
+
+    policy = DDNSPolicy.objects.create(name="ttl", ddns_ttl_percent=Decimal("0.3333"))
+    out = policy.to_kea_overrides()["ddns-ttl-percent"]
+    assert isinstance(out, float)
+    assert abs(out - 0.3333) < 1e-9
+
+
+def test_ddnspolicy_to_kea_overrides_drops_empty_strings(db):
+    from netbox_dhcp_kea_plugin.models import DDNSPolicy
+
+    policy = DDNSPolicy.objects.create(
+        name="emptystrs",
+        ddns_qualifying_suffix="",
+        ddns_generated_prefix="",
+    )
+    assert policy.to_kea_overrides() == {}
+
+
+# ---------------------------------------------------------------------------
+# D2Daemon
+# ---------------------------------------------------------------------------
+
+
+def test_d2daemon_to_kea_dict_partitions_forward_and_reverse(
+    db, d2_daemon, name_server
+):
+    from netbox_dhcp_kea_plugin.models import DDNSDomain
+
+    fwd_zone = _make_zone("fwd.example.com")
+    rev_zone = _make_zone("0.10.in-addr.arpa")
+    _attach_ns_to_zone(fwd_zone, name_server)
+    _attach_ns_to_zone(rev_zone, name_server)
+    DDNSDomain.objects.create(d2_daemon=d2_daemon, zone=fwd_zone)
+    DDNSDomain.objects.create(d2_daemon=d2_daemon, zone=rev_zone)
+
+    config = d2_daemon.to_kea_dict()["DhcpDdns"]
+    fwd_names = [d["name"] for d in config["forward-ddns"]["ddns-domains"]]
+    rev_names = [d["name"] for d in config["reverse-ddns"]["ddns-domains"]]
+    assert any(n.startswith("fwd.") for n in fwd_names)
+    assert any("in-addr.arpa" in n for n in rev_names)
+
+
+def test_d2daemon_to_kea_dict_emits_unique_tsig_keys(
+    db, d2_daemon, tsig_key, name_server
+):
+    from netbox_dhcp_kea_plugin.models import DDNSDomain
+
+    z1 = _make_zone("a.example.com")
+    z2 = _make_zone("b.example.com")
+    for z in (z1, z2):
+        _attach_ns_to_zone(z, name_server)
+        DDNSDomain.objects.create(d2_daemon=d2_daemon, zone=z, tsig_key=tsig_key)
+
+    config = d2_daemon.to_kea_dict()["DhcpDdns"]
+    assert "tsig-keys" in config
+    assert len(config["tsig-keys"]) == 1
+    assert config["tsig-keys"][0]["name"] == tsig_key.name

--- a/tests/test_ddns_models.py
+++ b/tests/test_ddns_models.py
@@ -344,3 +344,30 @@ def test_d2daemon_to_kea_dict_emits_unique_tsig_keys(
     assert "tsig-keys" in config
     assert len(config["tsig-keys"]) == 1
     assert config["tsig-keys"][0]["name"] == tsig_key.name
+
+
+def test_d2daemon_listener_ip_local_mode(db):
+    from netbox_dhcp_kea_plugin.models import D2Daemon
+
+    d = D2Daemon.objects.create(name="local-only", listener_mode="local")
+    assert d.listener_ip == "127.0.0.1"
+    assert d.to_kea_dict()["DhcpDdns"]["ip-address"] == "127.0.0.1"
+
+
+def test_d2daemon_listener_ip_remote_mode(db):
+    from ipam.models import IPAddress
+
+    from netbox_dhcp_kea_plugin.models import D2Daemon
+
+    ip = IPAddress.objects.create(address="10.99.0.50/24")
+    d = D2Daemon.objects.create(name="remote-only", listener_mode="remote", ip_address=ip)
+    assert d.listener_ip == "10.99.0.50"
+
+
+def test_d2daemon_remote_mode_requires_ip_address(db):
+    from netbox_dhcp_kea_plugin.models import D2Daemon
+
+    d = D2Daemon(name="bad-remote", listener_mode="remote")
+    with pytest.raises(ValidationError) as exc:
+        d.full_clean()
+    assert "ip_address" in exc.value.message_dict

--- a/tests/test_ddns_models.py
+++ b/tests/test_ddns_models.py
@@ -118,7 +118,7 @@ def test_tsig_key_clean_accepts_valid_base64():
     key.full_clean()
 
 
-def test_tsig_key_clean_rejects_non_base64():
+def test_tsig_key_clean_regenerates_for_non_base64():
     from netbox_dhcp_kea_plugin.models import TSIGKey
 
     key = TSIGKey(
@@ -127,9 +127,10 @@ def test_tsig_key_clean_rejects_non_base64():
         secret_backend="plaintext",
         secret_plaintext="not!base64!!",
     )
-    with pytest.raises(ValidationError) as exc:
-        key.full_clean()
-    assert "secret_plaintext" in exc.value.message_dict
+    key.full_clean()
+    assert key.secret_plaintext != "not!base64!!"
+    decoded = base64.b64decode(key.secret_plaintext, validate=True)
+    assert len(decoded) == 32  # HMAC-SHA256 natural length
 
 
 def test_tsig_key_clean_rejects_oversize_digest_bits():
@@ -147,17 +148,18 @@ def test_tsig_key_clean_rejects_oversize_digest_bits():
     assert "digest_bits" in exc.value.message_dict
 
 
-def test_tsig_key_clean_requires_secret_for_plaintext_backend():
+def test_tsig_key_clean_generates_when_empty_plaintext():
     from netbox_dhcp_kea_plugin.models import TSIGKey
 
     key = TSIGKey(
         name="empty.",
-        algorithm="HMAC-SHA256",
+        algorithm="HMAC-SHA1",
         secret_backend="plaintext",
         secret_plaintext="",
     )
-    with pytest.raises(ValidationError):
-        key.full_clean()
+    key.full_clean()
+    decoded = base64.b64decode(key.secret_plaintext, validate=True)
+    assert len(decoded) == 20  # HMAC-SHA1 natural length
 
 
 def test_tsig_key_get_secret_plaintext(tsig_key):

--- a/uv.lock
+++ b/uv.lock
@@ -1,0 +1,624 @@
+version = 1
+revision = 3
+requires-python = ">=3.12.0"
+resolution-markers = [
+    "python_full_version >= '3.15'",
+    "python_full_version < '3.15'",
+]
+
+[[package]]
+name = "asgiref"
+version = "3.11.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/63/40/f03da1264ae8f7cfdbf9146542e5e7e8100a4c66ab48e791df9a03d3f6c0/asgiref-3.11.1.tar.gz", hash = "sha256:5f184dc43b7e763efe848065441eac62229c9f7b0475f41f80e207a114eda4ce", size = 38550, upload-time = "2026-02-03T13:30:14.33Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5c/0a/a72d10ed65068e115044937873362e6e32fab1b7dce0046aeb224682c989/asgiref-3.11.1-py3-none-any.whl", hash = "sha256:e8667a091e69529631969fd45dc268fa79b99c92c5fcdda727757e52146ec133", size = 24345, upload-time = "2026-02-03T13:30:13.039Z" },
+]
+
+[[package]]
+name = "build"
+version = "1.4.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "os_name == 'nt'" },
+    { name = "packaging" },
+    { name = "pyproject-hooks" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/02/ec/bf5ae0a7e5ab57abe8aabdd0759c971883895d1a20c49ae99f8146840c3c/build-1.4.4.tar.gz", hash = "sha256:f832ae053061f3fb524af812dc94b8b84bac6880cd587630e3b5d91a6a9c1703", size = 89220, upload-time = "2026-04-22T20:53:44.807Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fa/88/6764e7a109dd84294850741501145da90d13cdeac9d4e614929464a37420/build-1.4.4-py3-none-any.whl", hash = "sha256:8c3f48a6090b39edec1a273d2d57949aaf13723b01e02f9d518396887519f64d", size = 25921, upload-time = "2026-04-22T20:53:43.251Z" },
+]
+
+[[package]]
+name = "cfgv"
+version = "3.5.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4e/b5/721b8799b04bf9afe054a3899c6cf4e880fcf8563cc71c15610242490a0c/cfgv-3.5.0.tar.gz", hash = "sha256:d5b1034354820651caa73ede66a6294d6e95c1b00acc5e9b098e917404669132", size = 7334, upload-time = "2025-11-19T20:55:51.612Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl", hash = "sha256:a8dc6b26ad22ff227d2634a65cb388215ce6cc96bbcc5cfde7641ae87e8dacc0", size = 7445, upload-time = "2025-11-19T20:55:50.744Z" },
+]
+
+[[package]]
+name = "check-manifest"
+version = "0.49"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "build" },
+    { name = "setuptools" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/bc/b3/33f739b91114bd2c6f019f0fd2cc679e58bfb5bd0d56327021f97b85499a/check-manifest-0.49.tar.gz", hash = "sha256:64a640445542cf226919657c7b78d02d9c1ca5b1c25d7e66e0e1ff325060f416", size = 40272, upload-time = "2022-12-05T08:15:00.797Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/86/42/5220a120cd50b1483c17d303e95d579047ae0d85150eedba7417574db29e/check_manifest-0.49-py3-none-any.whl", hash = "sha256:058cd30057714c39b96ce4d83f254fc770e3145c7b1932b5940b4e3efb5521ef", size = 20389, upload-time = "2022-12-05T08:14:58.535Z" },
+]
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "coverage"
+version = "7.13.5"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9d/e0/70553e3000e345daff267cec284ce4cbf3fc141b6da229ac52775b5428f1/coverage-7.13.5.tar.gz", hash = "sha256:c81f6515c4c40141f83f502b07bbfa5c240ba25bbe73da7b33f1e5b6120ff179", size = 915967, upload-time = "2026-03-17T10:33:18.341Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/c3/a396306ba7db865bf96fc1fb3b7fd29bcbf3d829df642e77b13555163cd6/coverage-7.13.5-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:460cf0114c5016fa841214ff5564aa4864f11948da9440bc97e21ad1f4ba1e01", size = 219554, upload-time = "2026-03-17T10:30:42.208Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/16/a68a19e5384e93f811dccc51034b1fd0b865841c390e3c931dcc4699e035/coverage-7.13.5-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:0e223ce4b4ed47f065bfb123687686512e37629be25cc63728557ae7db261422", size = 219908, upload-time = "2026-03-17T10:30:43.906Z" },
+    { url = "https://files.pythonhosted.org/packages/29/72/20b917c6793af3a5ceb7fb9c50033f3ec7865f2911a1416b34a7cfa0813b/coverage-7.13.5-cp312-cp312-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:6e3370441f4513c6252bf042b9c36d22491142385049243253c7e48398a15a9f", size = 251419, upload-time = "2026-03-17T10:30:45.545Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/49/cd14b789536ac6a4778c453c6a2338bc0a2fb60c5a5a41b4008328b9acc1/coverage-7.13.5-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:03ccc709a17a1de074fb1d11f217342fb0d2b1582ed544f554fc9fc3f07e95f5", size = 254159, upload-time = "2026-03-17T10:30:47.204Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/00/7b0edcfe64e2ed4c0340dac14a52ad0f4c9bd0b8b5e531af7d55b703db7c/coverage-7.13.5-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3f4818d065964db3c1c66dc0fbdac5ac692ecbc875555e13374fdbe7eedb4376", size = 255270, upload-time = "2026-03-17T10:30:48.812Z" },
+    { url = "https://files.pythonhosted.org/packages/93/89/7ffc4ba0f5d0a55c1e84ea7cee39c9fc06af7b170513d83fbf3bbefce280/coverage-7.13.5-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:012d5319e66e9d5a218834642d6c35d265515a62f01157a45bcc036ecf947256", size = 257538, upload-time = "2026-03-17T10:30:50.77Z" },
+    { url = "https://files.pythonhosted.org/packages/81/bd/73ddf85f93f7e6fa83e77ccecb6162d9415c79007b4bc124008a4995e4a7/coverage-7.13.5-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:8dd02af98971bdb956363e4827d34425cb3df19ee550ef92855b0acb9c7ce51c", size = 251821, upload-time = "2026-03-17T10:30:52.5Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/81/278aff4e8dec4926a0bcb9486320752811f543a3ce5b602cc7a29978d073/coverage-7.13.5-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:f08fd75c50a760c7eb068ae823777268daaf16a80b918fa58eea888f8e3919f5", size = 253191, upload-time = "2026-03-17T10:30:54.543Z" },
+    { url = "https://files.pythonhosted.org/packages/70/ee/fe1621488e2e0a58d7e94c4800f0d96f79671553488d401a612bebae324b/coverage-7.13.5-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:843ea8643cf967d1ac7e8ecd4bb00c99135adf4816c0c0593fdcc47b597fcf09", size = 251337, upload-time = "2026-03-17T10:30:56.663Z" },
+    { url = "https://files.pythonhosted.org/packages/37/a6/f79fb37aa104b562207cc23cb5711ab6793608e246cae1e93f26b2236ed9/coverage-7.13.5-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:9d44d7aa963820b1b971dbecd90bfe5fe8f81cff79787eb6cca15750bd2f79b9", size = 255404, upload-time = "2026-03-17T10:30:58.427Z" },
+    { url = "https://files.pythonhosted.org/packages/75/f0/ed15262a58ec81ce457ceb717b7f78752a1713556b19081b76e90896e8d4/coverage-7.13.5-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:7132bed4bd7b836200c591410ae7d97bf7ae8be6fc87d160b2bd881df929e7bf", size = 250903, upload-time = "2026-03-17T10:31:00.093Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/e9/9129958f20e7e9d4d56d51d42ccf708d15cac355ff4ac6e736e97a9393d2/coverage-7.13.5-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:a698e363641b98843c517817db75373c83254781426e94ada3197cabbc2c919c", size = 252780, upload-time = "2026-03-17T10:31:01.916Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/d7/0ad9b15812d81272db94379fe4c6df8fd17781cc7671fdfa30c76ba5ff7b/coverage-7.13.5-cp312-cp312-win32.whl", hash = "sha256:bdba0a6b8812e8c7df002d908a9a2ea3c36e92611b5708633c50869e6d922fdf", size = 222093, upload-time = "2026-03-17T10:31:03.642Z" },
+    { url = "https://files.pythonhosted.org/packages/29/3d/821a9a5799fac2556bcf0bd37a70d1d11fa9e49784b6d22e92e8b2f85f18/coverage-7.13.5-cp312-cp312-win_amd64.whl", hash = "sha256:d2c87e0c473a10bffe991502eac389220533024c8082ec1ce849f4218dded810", size = 222900, upload-time = "2026-03-17T10:31:05.651Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/fa/2238c2ad08e35cf4f020ea721f717e09ec3152aea75d191a7faf3ef009a8/coverage-7.13.5-cp312-cp312-win_arm64.whl", hash = "sha256:bf69236a9a81bdca3bff53796237aab096cdbf8d78a66ad61e992d9dac7eb2de", size = 221515, upload-time = "2026-03-17T10:31:07.293Z" },
+    { url = "https://files.pythonhosted.org/packages/74/8c/74fedc9663dcf168b0a059d4ea756ecae4da77a489048f94b5f512a8d0b3/coverage-7.13.5-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:5ec4af212df513e399cf11610cc27063f1586419e814755ab362e50a85ea69c1", size = 219576, upload-time = "2026-03-17T10:31:09.045Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/c9/44fb661c55062f0818a6ffd2685c67aa30816200d5f2817543717d4b92eb/coverage-7.13.5-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:941617e518602e2d64942c88ec8499f7fbd49d3f6c4327d3a71d43a1973032f3", size = 219942, upload-time = "2026-03-17T10:31:10.708Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/13/93419671cee82b780bab7ea96b67c8ef448f5f295f36bf5031154ec9a790/coverage-7.13.5-cp313-cp313-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:da305e9937617ee95c2e39d8ff9f040e0487cbf1ac174f777ed5eddd7a7c1f26", size = 250935, upload-time = "2026-03-17T10:31:12.392Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/68/1666e3a4462f8202d836920114fa7a5ee9275d1fa45366d336c551a162dd/coverage-7.13.5-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:78e696e1cc714e57e8b25760b33a8b1026b7048d270140d25dafe1b0a1ee05a3", size = 253541, upload-time = "2026-03-17T10:31:14.247Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/5e/3ee3b835647be646dcf3c65a7c6c18f87c27326a858f72ab22c12730773d/coverage-7.13.5-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:02ca0eed225b2ff301c474aeeeae27d26e2537942aa0f87491d3e147e784a82b", size = 254780, upload-time = "2026-03-17T10:31:16.193Z" },
+    { url = "https://files.pythonhosted.org/packages/44/b3/cb5bd1a04cfcc49ede6cd8409d80bee17661167686741e041abc7ee1b9a9/coverage-7.13.5-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:04690832cbea4e4663d9149e05dba142546ca05cb1848816760e7f58285c970a", size = 256912, upload-time = "2026-03-17T10:31:17.89Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/66/c1dceb7b9714473800b075f5c8a84f4588f887a90eb8645282031676e242/coverage-7.13.5-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:0590e44dd2745c696a778f7bab6aa95256de2cbc8b8cff4f7db8ff09813d6969", size = 251165, upload-time = "2026-03-17T10:31:19.605Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/62/5502b73b97aa2e53ea22a39cf8649ff44827bef76d90bf638777daa27a9d/coverage-7.13.5-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:d7cfad2d6d81dd298ab6b89fe72c3b7b05ec7544bdda3b707ddaecff8d25c161", size = 252908, upload-time = "2026-03-17T10:31:21.312Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/37/7792c2d69854397ca77a55c4646e5897c467928b0e27f2d235d83b5d08c6/coverage-7.13.5-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:e092b9499de38ae0fbfbc603a74660eb6ff3e869e507b50d85a13b6db9863e15", size = 250873, upload-time = "2026-03-17T10:31:23.565Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/23/bc866fb6163be52a8a9e5d708ba0d3b1283c12158cefca0a8bbb6e247a43/coverage-7.13.5-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:48c39bc4a04d983a54a705a6389512883d4a3b9862991b3617d547940e9f52b1", size = 255030, upload-time = "2026-03-17T10:31:25.58Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/8b/ef67e1c222ef49860701d346b8bbb70881bef283bd5f6cbba68a39a086c7/coverage-7.13.5-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:2d3807015f138ffea1ed9afeeb8624fd781703f2858b62a8dd8da5a0994c57b6", size = 250694, upload-time = "2026-03-17T10:31:27.316Z" },
+    { url = "https://files.pythonhosted.org/packages/46/0d/866d1f74f0acddbb906db212e096dee77a8e2158ca5e6bb44729f9d93298/coverage-7.13.5-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:ee2aa19e03161671ec964004fb74b2257805d9710bf14a5c704558b9d8dbaf17", size = 252469, upload-time = "2026-03-17T10:31:29.472Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/f5/be742fec31118f02ce42b21c6af187ad6a344fed546b56ca60caacc6a9a0/coverage-7.13.5-cp313-cp313-win32.whl", hash = "sha256:ce1998c0483007608c8382f4ff50164bfc5bd07a2246dd272aa4043b75e61e85", size = 222112, upload-time = "2026-03-17T10:31:31.526Z" },
+    { url = "https://files.pythonhosted.org/packages/66/40/7732d648ab9d069a46e686043241f01206348e2bbf128daea85be4d6414b/coverage-7.13.5-cp313-cp313-win_amd64.whl", hash = "sha256:631efb83f01569670a5e866ceb80fe483e7c159fac6f167e6571522636104a0b", size = 222923, upload-time = "2026-03-17T10:31:33.633Z" },
+    { url = "https://files.pythonhosted.org/packages/48/af/fea819c12a095781f6ccd504890aaddaf88b8fab263c4940e82c7b770124/coverage-7.13.5-cp313-cp313-win_arm64.whl", hash = "sha256:f4cd16206ad171cbc2470dbea9103cf9a7607d5fe8c242fdf1edf36174020664", size = 221540, upload-time = "2026-03-17T10:31:35.445Z" },
+    { url = "https://files.pythonhosted.org/packages/23/d2/17879af479df7fbbd44bd528a31692a48f6b25055d16482fdf5cdb633805/coverage-7.13.5-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:0428cbef5783ad91fe240f673cc1f76b25e74bbfe1a13115e4aa30d3f538162d", size = 220262, upload-time = "2026-03-17T10:31:37.184Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/4c/d20e554f988c8f91d6a02c5118f9abbbf73a8768a3048cb4962230d5743f/coverage-7.13.5-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:e0b216a19534b2427cc201a26c25da4a48633f29a487c61258643e89d28200c0", size = 220617, upload-time = "2026-03-17T10:31:39.245Z" },
+    { url = "https://files.pythonhosted.org/packages/29/9c/f9f5277b95184f764b24e7231e166dfdb5780a46d408a2ac665969416d61/coverage-7.13.5-cp313-cp313t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:972a9cd27894afe4bc2b1480107054e062df08e671df7c2f18c205e805ccd806", size = 261912, upload-time = "2026-03-17T10:31:41.324Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/f6/7f1ab39393eeb50cfe4747ae8ef0e4fc564b989225aa1152e13a180d74f8/coverage-7.13.5-cp313-cp313t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:4b59148601efcd2bac8c4dbf1f0ad6391693ccf7a74b8205781751637076aee3", size = 263987, upload-time = "2026-03-17T10:31:43.724Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/d7/62c084fb489ed9c6fbdf57e006752e7c516ea46fd690e5ed8b8617c7d52e/coverage-7.13.5-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:505d7083c8b0c87a8fa8c07370c285847c1f77739b22e299ad75a6af6c32c5c9", size = 266416, upload-time = "2026-03-17T10:31:45.769Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/f6/df63d8660e1a0bff6125947afda112a0502736f470d62ca68b288ea762d8/coverage-7.13.5-cp313-cp313t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:60365289c3741e4db327e7baff2a4aaacf22f788e80fa4683393891b70a89fbd", size = 267558, upload-time = "2026-03-17T10:31:48.293Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/02/353ca81d36779bd108f6d384425f7139ac3c58c750dcfaafe5d0bee6436b/coverage-7.13.5-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:1b88c69c8ef5d4b6fe7dea66d6636056a0f6a7527c440e890cf9259011f5e606", size = 261163, upload-time = "2026-03-17T10:31:50.125Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/16/2e79106d5749bcaf3aee6d309123548e3276517cd7851faa8da213bc61bf/coverage-7.13.5-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:5b13955d31d1633cf9376908089b7cebe7d15ddad7aeaabcbe969a595a97e95e", size = 263981, upload-time = "2026-03-17T10:31:51.961Z" },
+    { url = "https://files.pythonhosted.org/packages/29/c7/c29e0c59ffa6942030ae6f50b88ae49988e7e8da06de7ecdbf49c6d4feae/coverage-7.13.5-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:f70c9ab2595c56f81a89620e22899eea8b212a4041bd728ac6f4a28bf5d3ddd0", size = 261604, upload-time = "2026-03-17T10:31:53.872Z" },
+    { url = "https://files.pythonhosted.org/packages/40/48/097cdc3db342f34006a308ab41c3a7c11c3f0d84750d340f45d88a782e00/coverage-7.13.5-cp313-cp313t-musllinux_1_2_ppc64le.whl", hash = "sha256:084b84a8c63e8d6fc7e3931b316a9bcafca1458d753c539db82d31ed20091a87", size = 265321, upload-time = "2026-03-17T10:31:55.997Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/1f/4994af354689e14fd03a75f8ec85a9a68d94e0188bbdab3fc1516b55e512/coverage-7.13.5-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:ad14385487393e386e2ea988b09d62dd42c397662ac2dabc3832d71253eee479", size = 260502, upload-time = "2026-03-17T10:31:58.308Z" },
+    { url = "https://files.pythonhosted.org/packages/22/c6/9bb9ef55903e628033560885f5c31aa227e46878118b63ab15dc7ba87797/coverage-7.13.5-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:7f2c47b36fe7709a6e83bfadf4eefb90bd25fbe4014d715224c4316f808e59a2", size = 262688, upload-time = "2026-03-17T10:32:00.141Z" },
+    { url = "https://files.pythonhosted.org/packages/14/4f/f5df9007e50b15e53e01edea486814783a7f019893733d9e4d6caad75557/coverage-7.13.5-cp313-cp313t-win32.whl", hash = "sha256:67e9bc5449801fad0e5dff329499fb090ba4c5800b86805c80617b4e29809b2a", size = 222788, upload-time = "2026-03-17T10:32:02.246Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/98/aa7fccaa97d0f3192bec013c4e6fd6d294a6ed44b640e6bb61f479e00ed5/coverage-7.13.5-cp313-cp313t-win_amd64.whl", hash = "sha256:da86cdcf10d2519e10cabb8ac2de03da1bcb6e4853790b7fbd48523332e3a819", size = 223851, upload-time = "2026-03-17T10:32:04.416Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/8b/e5c469f7352651e5f013198e9e21f97510b23de957dd06a84071683b4b60/coverage-7.13.5-cp313-cp313t-win_arm64.whl", hash = "sha256:0ecf12ecb326fe2c339d93fc131816f3a7367d223db37817208905c89bded911", size = 222104, upload-time = "2026-03-17T10:32:06.65Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/77/39703f0d1d4b478bfd30191d3c14f53caf596fac00efb3f8f6ee23646439/coverage-7.13.5-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:fbabfaceaeb587e16f7008f7795cd80d20ec548dc7f94fbb0d4ec2e038ce563f", size = 219621, upload-time = "2026-03-17T10:32:08.589Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/3e/51dff36d99ae14639a133d9b164d63e628532e2974d8b1edb99dd1ebc733/coverage-7.13.5-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:9bb2a28101a443669a423b665939381084412b81c3f8c0fcfbac57f4e30b5b8e", size = 219953, upload-time = "2026-03-17T10:32:10.507Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/6c/1f1917b01eb647c2f2adc9962bd66c79eb978951cab61bdc1acab3290c07/coverage-7.13.5-cp314-cp314-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:bd3a2fbc1c6cccb3c5106140d87cc6a8715110373ef42b63cf5aea29df8c217a", size = 250992, upload-time = "2026-03-17T10:32:12.41Z" },
+    { url = "https://files.pythonhosted.org/packages/22/e5/06b1f88f42a5a99df42ce61208bdec3bddb3d261412874280a19796fc09c/coverage-7.13.5-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:6c36ddb64ed9d7e496028d1d00dfec3e428e0aabf4006583bb1839958d280510", size = 253503, upload-time = "2026-03-17T10:32:14.449Z" },
+    { url = "https://files.pythonhosted.org/packages/80/28/2a148a51e5907e504fa7b85490277734e6771d8844ebcc48764a15e28155/coverage-7.13.5-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:380e8e9084d8eb38db3a9176a1a4f3c0082c3806fa0dc882d1d87abc3c789247", size = 254852, upload-time = "2026-03-17T10:32:16.56Z" },
+    { url = "https://files.pythonhosted.org/packages/61/77/50e8d3d85cc0b7ebe09f30f151d670e302c7ff4a1bf6243f71dd8b0981fa/coverage-7.13.5-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:e808af52a0513762df4d945ea164a24b37f2f518cbe97e03deaa0ee66139b4d6", size = 257161, upload-time = "2026-03-17T10:32:19.004Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/c4/b5fd1d4b7bf8d0e75d997afd3925c59ba629fc8616f1b3aae7605132e256/coverage-7.13.5-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e301d30dd7e95ae068671d746ba8c34e945a82682e62918e41b2679acd2051a0", size = 251021, upload-time = "2026-03-17T10:32:21.344Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/66/6ea21f910e92d69ef0b1c3346ea5922a51bad4446c9126db2ae96ee24c4c/coverage-7.13.5-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:800bc829053c80d240a687ceeb927a94fd108bbdc68dfbe505d0d75ab578a882", size = 252858, upload-time = "2026-03-17T10:32:23.506Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/ea/879c83cb5d61aa2a35fb80e72715e92672daef8191b84911a643f533840c/coverage-7.13.5-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:0b67af5492adb31940ee418a5a655c28e48165da5afab8c7fa6fd72a142f8740", size = 250823, upload-time = "2026-03-17T10:32:25.516Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/fb/616d95d3adb88b9803b275580bdeee8bd1b69a886d057652521f83d7322f/coverage-7.13.5-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:c9136ff29c3a91e25b1d1552b5308e53a1e0653a23e53b6366d7c2dcbbaf8a16", size = 255099, upload-time = "2026-03-17T10:32:27.944Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/93/25e6917c90ec1c9a56b0b26f6cad6408e5f13bb6b35d484a0d75c9cf000d/coverage-7.13.5-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:cff784eef7f0b8f6cb28804fbddcfa99f89efe4cc35fb5627e3ac58f91ed3ac0", size = 250638, upload-time = "2026-03-17T10:32:29.914Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/7b/dc1776b0464145a929deed214aef9fb1493f159b59ff3c7eeeedf91eddd0/coverage-7.13.5-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:68a4953be99b17ac3c23b6efbc8a38330d99680c9458927491d18700ef23ded0", size = 252295, upload-time = "2026-03-17T10:32:31.981Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/fb/99cbbc56a26e07762a2740713f3c8f9f3f3106e3a3dd8cc4474954bccd34/coverage-7.13.5-cp314-cp314-win32.whl", hash = "sha256:35a31f2b1578185fbe6aa2e74cea1b1d0bbf4c552774247d9160d29b80ed56cc", size = 222360, upload-time = "2026-03-17T10:32:34.233Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/b7/4758d4f73fb536347cc5e4ad63662f9d60ba9118cb6785e9616b2ce5d7fa/coverage-7.13.5-cp314-cp314-win_amd64.whl", hash = "sha256:2aa055ae1857258f9e0045be26a6d62bdb47a72448b62d7b55f4820f361a2633", size = 223174, upload-time = "2026-03-17T10:32:36.369Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/f2/24d84e1dfe70f8ac9fdf30d338239860d0d1d5da0bda528959d0ebc9da28/coverage-7.13.5-cp314-cp314-win_arm64.whl", hash = "sha256:1b11eef33edeae9d142f9b4358edb76273b3bfd30bc3df9a4f95d0e49caf94e8", size = 221739, upload-time = "2026-03-17T10:32:38.736Z" },
+    { url = "https://files.pythonhosted.org/packages/60/5b/4a168591057b3668c2428bff25dd3ebc21b629d666d90bcdfa0217940e84/coverage-7.13.5-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:10a0c37f0b646eaff7cce1874c31d1f1ccb297688d4c747291f4f4c70741cc8b", size = 220351, upload-time = "2026-03-17T10:32:41.196Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/21/1fd5c4dbfe4a58b6b99649125635df46decdfd4a784c3cd6d410d303e370/coverage-7.13.5-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:b5db73ba3c41c7008037fa731ad5459fc3944cb7452fc0aa9f822ad3533c583c", size = 220612, upload-time = "2026-03-17T10:32:43.204Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/fe/2a924b3055a5e7e4512655a9d4609781b0d62334fa0140c3e742926834e2/coverage-7.13.5-cp314-cp314t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:750db93a81e3e5a9831b534be7b1229df848b2e125a604fe6651e48aa070e5f9", size = 261985, upload-time = "2026-03-17T10:32:45.514Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/0d/c8928f2bd518c45990fe1a2ab8db42e914ef9b726c975facc4282578c3eb/coverage-7.13.5-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:9ddb4f4a5479f2539644be484da179b653273bca1a323947d48ab107b3ed1f29", size = 264107, upload-time = "2026-03-17T10:32:47.971Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/ae/4ae35bbd9a0af9d820362751f0766582833c211224b38665c0f8de3d487f/coverage-7.13.5-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d8a7a2049c14f413163e2bdabd37e41179b1d1ccb10ffc6ccc4b7a718429c607", size = 266513, upload-time = "2026-03-17T10:32:50.1Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/20/d326174c55af36f74eac6ae781612d9492f060ce8244b570bb9d50d9d609/coverage-7.13.5-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:e1c85e0b6c05c592ea6d8768a66a254bfb3874b53774b12d4c89c481eb78cb90", size = 267650, upload-time = "2026-03-17T10:32:52.391Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/5e/31484d62cbd0eabd3412e30d74386ece4a0837d4f6c3040a653878bfc019/coverage-7.13.5-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:777c4d1eff1b67876139d24288aaf1817f6c03d6bae9c5cc8d27b83bcfe38fe3", size = 261089, upload-time = "2026-03-17T10:32:54.544Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/d8/49a72d6de146eebb0b7e48cc0f4bc2c0dd858e3d4790ab2b39a2872b62bd/coverage-7.13.5-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:6697e29b93707167687543480a40f0db8f356e86d9f67ddf2e37e2dfd91a9dab", size = 263982, upload-time = "2026-03-17T10:32:56.803Z" },
+    { url = "https://files.pythonhosted.org/packages/06/3b/0351f1bd566e6e4dd39e978efe7958bde1d32f879e85589de147654f57bb/coverage-7.13.5-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:8fdf453a942c3e4d99bd80088141c4c6960bb232c409d9c3558e2dbaa3998562", size = 261579, upload-time = "2026-03-17T10:32:59.466Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/ce/796a2a2f4017f554d7810f5c573449b35b1e46788424a548d4d19201b222/coverage-7.13.5-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:32ca0c0114c9834a43f045a87dcebd69d108d8ffb666957ea65aa132f50332e2", size = 265316, upload-time = "2026-03-17T10:33:01.847Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/16/d5ae91455541d1a78bc90abf495be600588aff8f6db5c8b0dae739fa39c9/coverage-7.13.5-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:8769751c10f339021e2638cd354e13adeac54004d1941119b2c96fe5276d45ea", size = 260427, upload-time = "2026-03-17T10:33:03.945Z" },
+    { url = "https://files.pythonhosted.org/packages/48/11/07f413dba62db21fb3fad5d0de013a50e073cc4e2dc4306e770360f6dfc8/coverage-7.13.5-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:cec2d83125531bd153175354055cdb7a09987af08a9430bd173c937c6d0fba2a", size = 262745, upload-time = "2026-03-17T10:33:06.285Z" },
+    { url = "https://files.pythonhosted.org/packages/91/15/d792371332eb4663115becf4bad47e047d16234b1aff687b1b18c58d60ae/coverage-7.13.5-cp314-cp314t-win32.whl", hash = "sha256:0cd9ed7a8b181775459296e402ca4fb27db1279740a24e93b3b41942ebe4b215", size = 223146, upload-time = "2026-03-17T10:33:08.756Z" },
+    { url = "https://files.pythonhosted.org/packages/db/51/37221f59a111dca5e85be7dbf09696323b5b9f13ff65e0641d535ed06ea8/coverage-7.13.5-cp314-cp314t-win_amd64.whl", hash = "sha256:301e3b7dfefecaca37c9f1aa6f0049b7d4ab8dd933742b607765d757aca77d43", size = 224254, upload-time = "2026-03-17T10:33:11.174Z" },
+    { url = "https://files.pythonhosted.org/packages/54/83/6acacc889de8987441aa7d5adfbdbf33d288dad28704a67e574f1df9bcbb/coverage-7.13.5-cp314-cp314t-win_arm64.whl", hash = "sha256:9dacc2ad679b292709e0f5fc1ac74a6d4d5562e424058962c7bb0c658ad25e45", size = 222276, upload-time = "2026-03-17T10:33:13.466Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/ee/a4cf96b8ce1e566ed238f0659ac2d3f007ed1d14b181bcb684e19561a69a/coverage-7.13.5-py3-none-any.whl", hash = "sha256:34b02417cf070e173989b3db962f7ed56d2f644307b2cf9d5a0f258e13084a61", size = 211346, upload-time = "2026-03-17T10:33:15.691Z" },
+]
+
+[[package]]
+name = "distlib"
+version = "0.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/96/8e/709914eb2b5749865801041647dc7f4e6d00b549cfe88b65ca192995f07c/distlib-0.4.0.tar.gz", hash = "sha256:feec40075be03a04501a973d81f633735b4b69f98b05450592310c0f401a4e0d", size = 614605, upload-time = "2025-07-17T16:52:00.465Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/33/6b/e0547afaf41bf2c42e52430072fa5658766e3d65bd4b03a563d1b6336f57/distlib-0.4.0-py2.py3-none-any.whl", hash = "sha256:9659f7d87e46584a30b5780e43ac7a2143098441670ff0a49d5f9034c54a6c16", size = 469047, upload-time = "2025-07-17T16:51:58.613Z" },
+]
+
+[[package]]
+name = "django"
+version = "6.0.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "asgiref" },
+    { name = "sqlparse" },
+    { name = "tzdata", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/60/b9/4155091ad1788b38563bd77a7258c0834e8c12a7f56f6975deaf54f8b61d/django-6.0.4.tar.gz", hash = "sha256:8cfa2572b3f2768b2e84983cf3c4811877a01edb64e817986ec5d60751c113ac", size = 10907407, upload-time = "2026-04-07T13:55:44.961Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e9/47/3d61d611609764aa71a37f7037b870e7bfb22937366974c4fd46cada7bab/django-6.0.4-py3-none-any.whl", hash = "sha256:14359c809fc16e8f81fd2b59d7d348e4d2d799da6840b10522b6edf7b8afc1da", size = 8368342, upload-time = "2026-04-07T13:55:37.999Z" },
+]
+
+[[package]]
+name = "django-stubs"
+version = "6.0.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "django" },
+    { name = "django-stubs-ext" },
+    { name = "types-pyyaml" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/86/0c/8d0d875af79bf774c1c3997c84aa118dba3a77be12086b9c14e130e8ec72/django_stubs-6.0.3.tar.gz", hash = "sha256:ee895f403c373608eeb50822f0733f9d9ec5ab12731d4ab58956053bb95fdd9e", size = 278214, upload-time = "2026-04-18T15:11:22.327Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/80/a3/6751b7684d20fc4f228bdd3dd8341d382ab3faaf65d3d050c0d59ab0a1b0/django_stubs-6.0.3-py3-none-any.whl", hash = "sha256:5fee22bcbbad59a78c727a820b6f4e68ff442ca76a922b7002e57c25dd7cb390", size = 541570, upload-time = "2026-04-18T15:11:20.711Z" },
+]
+
+[package.optional-dependencies]
+compatible-mypy = [
+    { name = "mypy" },
+]
+
+[[package]]
+name = "django-stubs-ext"
+version = "6.0.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "django" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fb/e6/5dcdaa785ec3eed5fc196c7e68fb7ad9d9fe6d5acccea4690e65f2546417/django_stubs_ext-6.0.3.tar.gz", hash = "sha256:3307d42132bc295d5744de6276bc5fdf6896efc70f891e21c0ae8bdf529d2762", size = 6663, upload-time = "2026-04-18T15:10:53.667Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/10/fa/0a3a05c29d6295dbd52fa3cb4047a95de11ba4f2696072d6f3f2c1e6f370/django_stubs_ext-6.0.3-py3-none-any.whl", hash = "sha256:9e4105955419ae310d7da9cfd808e039d4dae3092c628f021057bb4f2c237f8f", size = 10354, upload-time = "2026-04-18T15:10:52.395Z" },
+]
+
+[[package]]
+name = "filelock"
+version = "3.29.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b5/fe/997687a931ab51049acce6fa1f23e8f01216374ea81374ddee763c493db5/filelock-3.29.0.tar.gz", hash = "sha256:69974355e960702e789734cb4871f884ea6fe50bd8404051a3530bc07809cf90", size = 57571, upload-time = "2026-04-19T15:39:10.068Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/81/47/dd9a212ef6e343a6857485ffe25bba537304f1913bdbed446a23f7f592e1/filelock-3.29.0-py3-none-any.whl", hash = "sha256:96f5f6344709aa1572bbf631c640e4ebeeb519e08da902c39a001882f30ac258", size = 39812, upload-time = "2026-04-19T15:39:08.752Z" },
+]
+
+[[package]]
+name = "identify"
+version = "2.6.19"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/52/63/51723b5f116cc04b061cb6f5a561790abf249d25931d515cd375e063e0f4/identify-2.6.19.tar.gz", hash = "sha256:6be5020c38fcb07da56c53733538a3081ea5aa70d36a156f83044bfbf9173842", size = 99567, upload-time = "2026-04-17T18:39:50.265Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/94/84/d9273cd09688070a6523c4aee4663a8538721b2b755c4962aafae0011e72/identify-2.6.19-py2.py3-none-any.whl", hash = "sha256:20e6a87f786f768c092a721ad107fc9df0eb89347be9396cadf3f4abbd1fb78a", size = 99397, upload-time = "2026-04-17T18:39:49.221Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "librt"
+version = "0.9.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/eb/6b/3d5c13fb3e3c4f43206c8f9dfed13778c2ed4f000bacaa0b7ce3c402a265/librt-0.9.0.tar.gz", hash = "sha256:a0951822531e7aee6e0dfb556b30d5ee36bbe234faf60c20a16c01be3530869d", size = 184368, upload-time = "2026-04-09T16:06:26.173Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bf/90/89ddba8e1c20b0922783cd93ed8e64f34dc05ab59c38a9c7e313632e20ff/librt-0.9.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:9b3e3bc363f71bda1639a4ee593cb78f7fbfeacc73411ec0d4c92f00730010a4", size = 68332, upload-time = "2026-04-09T16:05:00.09Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/40/7aa4da1fb08bdeeb540cb07bfc8207cb32c5c41642f2594dbd0098a0662d/librt-0.9.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:0a09c2f5869649101738653a9b7ab70cf045a1105ac66cbb8f4055e61df78f2d", size = 70581, upload-time = "2026-04-09T16:05:01.213Z" },
+    { url = "https://files.pythonhosted.org/packages/48/ac/73a2187e1031041e93b7e3a25aae37aa6f13b838c550f7e0f06f66766212/librt-0.9.0-cp312-cp312-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:5ca8e133d799c948db2ab1afc081c333a825b5540475164726dcbf73537e5c2f", size = 203984, upload-time = "2026-04-09T16:05:02.542Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/3d/23460d571e9cbddb405b017681df04c142fb1b04cbfce77c54b08e28b108/librt-0.9.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:603138ee838ee1583f1b960b62d5d0007845c5c423feb68e44648b1359014e27", size = 215762, upload-time = "2026-04-09T16:05:04.127Z" },
+    { url = "https://files.pythonhosted.org/packages/de/1e/42dc7f8ab63e65b20640d058e63e97fd3e482c1edbda3570d813b4d0b927/librt-0.9.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f4003f70c56a5addd6aa0897f200dd59afd3bf7bcd5b3cce46dd21f925743bc2", size = 230288, upload-time = "2026-04-09T16:05:05.883Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/08/ca812b6d8259ad9ece703397f8ad5c03af5b5fedfce64279693d3ce4087c/librt-0.9.0-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:78042f6facfd98ecb25e9829c7e37cce23363d9d7c83bc5f72702c5059eb082b", size = 224103, upload-time = "2026-04-09T16:05:07.148Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/3f/620490fb2fa66ffd44e7f900254bc110ebec8dac6c1b7514d64662570e6f/librt-0.9.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:a361c9434a64d70a7dbb771d1de302c0cc9f13c0bffe1cf7e642152814b35265", size = 232122, upload-time = "2026-04-09T16:05:08.386Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/83/12864700a1b6a8be458cf5d05db209b0d8e94ae281e7ec261dbe616597b4/librt-0.9.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:dd2c7e082b0b92e1baa4da28163a808672485617bc855cc22a2fd06978fa9084", size = 225045, upload-time = "2026-04-09T16:05:09.707Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/1b/845d339c29dc7dbc87a2e992a1ba8d28d25d0e0372f9a0a2ecebde298186/librt-0.9.0-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:7e6274fd33fc5b2a14d41c9119629d3ff395849d8bcbc80cf637d9e8d2034da8", size = 227372, upload-time = "2026-04-09T16:05:10.942Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/fe/277985610269d926a64c606f761d58d3db67b956dbbf40024921e95e7fcb/librt-0.9.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:5093043afb226ecfa1400120d1ebd4442b4f99977783e4f4f7248879009b227f", size = 248224, upload-time = "2026-04-09T16:05:12.254Z" },
+    { url = "https://files.pythonhosted.org/packages/92/1b/ee486d244b8de6b8b5dbaefabe6bfdd4a72e08f6353edf7d16d27114da8d/librt-0.9.0-cp312-cp312-win32.whl", hash = "sha256:9edcc35d1cae9fd5320171b1a838c7da8a5c968af31e82ecc3dff30b4be0957f", size = 55986, upload-time = "2026-04-09T16:05:13.529Z" },
+    { url = "https://files.pythonhosted.org/packages/89/7a/ba1737012308c17dc6d5516143b5dce9a2c7ba3474afd54e11f44a4d1ef3/librt-0.9.0-cp312-cp312-win_amd64.whl", hash = "sha256:3cc2917258e131ae5f958a4d872e07555b51cb7466a43433218061c74ef33745", size = 63260, upload-time = "2026-04-09T16:05:14.68Z" },
+    { url = "https://files.pythonhosted.org/packages/36/e4/01752c113da15127f18f7bf11142f5640038f062407a611c059d0036c6aa/librt-0.9.0-cp312-cp312-win_arm64.whl", hash = "sha256:90e6d5420fc8a300518d4d2288154ff45005e920425c22cbbfe8330f3f754bd9", size = 53694, upload-time = "2026-04-09T16:05:16.095Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/d7/1b3e26fffde1452d82f5666164858a81c26ebe808e7ae8c9c88628981540/librt-0.9.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:f29b68cd9714531672db62cc54f6e8ff981900f824d13fa0e00749189e13778e", size = 68367, upload-time = "2026-04-09T16:05:17.243Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/5b/c61b043ad2e091fbe1f2d35d14795e545d0b56b03edaa390fa1dcee3d160/librt-0.9.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:7d5c8a5929ac325729f6119802070b561f4db793dffc45e9ac750992a4ed4d22", size = 70595, upload-time = "2026-04-09T16:05:18.471Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/22/2448471196d8a73370aa2f23445455dc42712c21404081fcd7a03b9e0749/librt-0.9.0-cp313-cp313-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:756775d25ec8345b837ab52effee3ad2f3b2dfd6bbee3e3f029c517bd5d8f05a", size = 204354, upload-time = "2026-04-09T16:05:19.593Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/5e/39fc4b153c78cfd2c8a2dcb32700f2d41d2312aa1050513183be4540930d/librt-0.9.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2b8f5d00b49818f4e2b1667db994488b045835e0ac16fe2f924f3871bd2b8ac5", size = 216238, upload-time = "2026-04-09T16:05:20.868Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/42/bc2d02d0fa7badfa63aa8d6dcd8793a9f7ef5a94396801684a51ed8d8287/librt-0.9.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c81aef782380f0f13ead670aae01825eb653b44b046aa0e5ebbb79f76ed4aa11", size = 230589, upload-time = "2026-04-09T16:05:22.305Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/7b/e2d95cc513866373692aa5edf98080d5602dd07cabfb9e5d2f70df2f25f7/librt-0.9.0-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:66b58fed90a545328e80d575467244de3741e088c1af928f0b489ebec3ef3858", size = 224610, upload-time = "2026-04-09T16:05:23.647Z" },
+    { url = "https://files.pythonhosted.org/packages/31/d5/6cec4607e998eaba57564d06a1295c21b0a0c8de76e4e74d699e627bd98c/librt-0.9.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:e78fb7419e07d98c2af4b8567b72b3eaf8cb05caad642e9963465569c8b2d87e", size = 232558, upload-time = "2026-04-09T16:05:25.025Z" },
+    { url = "https://files.pythonhosted.org/packages/95/8c/27f1d8d3aaf079d3eb26439bf0b32f1482340c3552e324f7db9dca858671/librt-0.9.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:2c3786f0f4490a5cd87f1ed6cefae833ad6b1060d52044ce0434a2e85893afd0", size = 225521, upload-time = "2026-04-09T16:05:26.311Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/d8/1e0d43b1c329b416017619469b3c3801a25a6a4ef4a1c68332aeaa6f72ca/librt-0.9.0-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:8494cfc61e03542f2d381e71804990b3931175a29b9278fdb4a5459948778dc2", size = 227789, upload-time = "2026-04-09T16:05:27.624Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/b4/d3d842e88610fcd4c8eec7067b0c23ef2d7d3bff31496eded6a83b0f99be/librt-0.9.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:07cf11f769831186eeac424376e6189f20ace4f7263e2134bdb9757340d84d4d", size = 248616, upload-time = "2026-04-09T16:05:29.181Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/28/527df8ad0d1eb6c8bdfa82fc190f1f7c4cca5a1b6d7b36aeabf95b52d74d/librt-0.9.0-cp313-cp313-win32.whl", hash = "sha256:850d6d03177e52700af605fd60db7f37dcb89782049a149674d1a9649c2138fd", size = 56039, upload-time = "2026-04-09T16:05:30.709Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/a7/413652ad0d92273ee5e30c000fc494b361171177c83e57c060ecd3c21538/librt-0.9.0-cp313-cp313-win_amd64.whl", hash = "sha256:a5af136bfba820d592f86c67affcef9b3ff4d4360ac3255e341e964489b48519", size = 63264, upload-time = "2026-04-09T16:05:31.881Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/0a/92c244309b774e290ddb15e93363846ae7aa753d9586b8aad511c5e6145b/librt-0.9.0-cp313-cp313-win_arm64.whl", hash = "sha256:4c4d0440a3a8e31d962340c3e1cc3fc9ee7febd34c8d8f770d06adb947779ea5", size = 53728, upload-time = "2026-04-09T16:05:33.31Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/c1/184e539543f06ea2912f4b92a5ffaede4f9b392689e3f00acbf8134bee92/librt-0.9.0-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:3f05d145df35dca5056a8bc3838e940efebd893a54b3e19b2dda39ceaa299bcb", size = 67830, upload-time = "2026-04-09T16:05:34.517Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/ad/23399bdcb7afca819acacdef31b37ee59de261bd66b503a7995c03c4b0dc/librt-0.9.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:1c587494461ebd42229d0f1739f3aa34237dd9980623ecf1be8d3bcba79f4499", size = 70280, upload-time = "2026-04-09T16:05:35.649Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/0b/4542dc5a2b8772dbf92cafb9194701230157e73c14b017b6961a23598b03/librt-0.9.0-cp314-cp314-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:b0a2040f801406b93657a70b72fa12311063a319fee72ce98e1524da7200171f", size = 201925, upload-time = "2026-04-09T16:05:36.739Z" },
+    { url = "https://files.pythonhosted.org/packages/31/d4/8ee7358b08fd0cfce051ef96695380f09b3c2c11b77c9bfbc367c921cce5/librt-0.9.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f38bc489037eca88d6ebefc9c4d41a4e07c8e8b4de5188a9e6d290273ad7ebb1", size = 212381, upload-time = "2026-04-09T16:05:38.043Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/94/a2025fe442abedf8b038038dab3dba942009ad42b38ea064a1a9e6094241/librt-0.9.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f3fd278f5e6bf7c75ccd6d12344eb686cc020712683363b66f46ac79d37c799f", size = 227065, upload-time = "2026-04-09T16:05:39.394Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/e9/b9fcf6afa909f957cfbbf918802f9dada1bd5d3c1da43d722fd6a310dc3f/librt-0.9.0-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:fcbdf2a9ca24e87bbebb47f1fe34e531ef06f104f98c9ccfc953a3f3344c567a", size = 221333, upload-time = "2026-04-09T16:05:40.999Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/7c/ba54cd6aa6a3c8cd12757a6870e0c79a64b1e6327f5248dcff98423f4d43/librt-0.9.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:e306d956cfa027fe041585f02a1602c32bfa6bb8ebea4899d373383295a6c62f", size = 229051, upload-time = "2026-04-09T16:05:42.605Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/4b/8cfdbad314c8677a0148bf0b70591d6d18587f9884d930276098a235461b/librt-0.9.0-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:465814ab157986acb9dfa5ccd7df944be5eefc0d08d31ec6e8d88bc71251d845", size = 222492, upload-time = "2026-04-09T16:05:43.842Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/d1/2eda69563a1a88706808decdce035e4b32755dbfbb0d05e1a65db9547ed1/librt-0.9.0-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:703f4ae36d6240bfe24f542bac784c7e4194ec49c3ba5a994d02891649e2d85b", size = 223849, upload-time = "2026-04-09T16:05:45.054Z" },
+    { url = "https://files.pythonhosted.org/packages/04/44/b2ed37df6be5b3d42cfe36318e0598e80843d5c6308dd63d0bf4e0ce5028/librt-0.9.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:3be322a15ee5e70b93b7a59cfd074614f22cc8c9ff18bd27f474e79137ea8d3b", size = 245001, upload-time = "2026-04-09T16:05:46.34Z" },
+    { url = "https://files.pythonhosted.org/packages/47/e7/617e412426df89169dd2a9ed0cc8752d5763336252c65dbf945199915119/librt-0.9.0-cp314-cp314-win32.whl", hash = "sha256:b8da9f8035bb417770b1e1610526d87ad4fc58a2804dc4d79c53f6d2cf5a6eb9", size = 51799, upload-time = "2026-04-09T16:05:47.738Z" },
+    { url = "https://files.pythonhosted.org/packages/24/ed/c22ca4db0ca3cbc285e4d9206108746beda561a9792289c3c31281d7e9df/librt-0.9.0-cp314-cp314-win_amd64.whl", hash = "sha256:b8bd70d5d816566a580d193326912f4a76ec2d28a97dc4cd4cc831c0af8e330e", size = 59165, upload-time = "2026-04-09T16:05:49.198Z" },
+    { url = "https://files.pythonhosted.org/packages/24/56/875398fafa4cbc8f15b89366fc3287304ddd3314d861f182a4b87595ace0/librt-0.9.0-cp314-cp314-win_arm64.whl", hash = "sha256:fc5758e2b7a56532dc33e3c544d78cbaa9ecf0a0f2a2da2df882c1d6b99a317f", size = 49292, upload-time = "2026-04-09T16:05:50.362Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/61/bc448ecbf9b2d69c5cff88fe41496b19ab2a1cbda0065e47d4d0d51c0867/librt-0.9.0-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:f24b90b0e0c8cc9491fb1693ae91fe17cb7963153a1946395acdbdd5818429a4", size = 70175, upload-time = "2026-04-09T16:05:51.564Z" },
+    { url = "https://files.pythonhosted.org/packages/60/f2/c47bb71069a73e2f04e70acbd196c1e5cc411578ac99039a224b98920fd4/librt-0.9.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:3fe56e80badb66fdcde06bef81bbaa5bfcf6fbd7aefb86222d9e369c38c6b228", size = 72951, upload-time = "2026-04-09T16:05:52.699Z" },
+    { url = "https://files.pythonhosted.org/packages/29/19/0549df59060631732df758e8886d92088da5fdbedb35b80e4643664e8412/librt-0.9.0-cp314-cp314t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:527b5b820b47a09e09829051452bb0d1dd2122261254e2a6f674d12f1d793d54", size = 225864, upload-time = "2026-04-09T16:05:53.895Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/f8/3b144396d302ac08e50f89e64452c38db84bc7b23f6c60479c5d3abd303c/librt-0.9.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7d429bdd4ac0ab17c8e4a8af0ed2a7440b16eba474909ab357131018fe8c7e71", size = 241155, upload-time = "2026-04-09T16:05:55.191Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/ce/ee67ec14581de4043e61d05786d2aed6c9b5338816b7859bcf07455c6a9f/librt-0.9.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7202bdcac47d3a708271c4304a474a8605a4a9a4a709e954bf2d3241140aa938", size = 252235, upload-time = "2026-04-09T16:05:56.549Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/fa/0ead15daa2b293a54101550b08d4bafe387b7d4a9fc6d2b985602bae69b6/librt-0.9.0-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:c0d620e74897f8c2613b3c4e2e9c1e422eb46d2ddd07df540784d44117836af3", size = 244963, upload-time = "2026-04-09T16:05:57.858Z" },
+    { url = "https://files.pythonhosted.org/packages/29/68/9fbf9a9aa704ba87689e40017e720aced8d9a4d2b46b82451d8142f91ec9/librt-0.9.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:d69fc39e627908f4c03297d5a88d9284b73f4d90b424461e32e8c2485e21c283", size = 257364, upload-time = "2026-04-09T16:05:59.686Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/8d/9d60869f1b6716c762e45f66ed945b1e5dd649f7377684c3b176ae424648/librt-0.9.0-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:c2640e23d2b7c98796f123ffd95cf2022c7777aa8a4a3b98b36c570d37e85eee", size = 247661, upload-time = "2026-04-09T16:06:00.938Z" },
+    { url = "https://files.pythonhosted.org/packages/70/ff/a5c365093962310bfdb4f6af256f191085078ffb529b3f0cbebb5b33ebe2/librt-0.9.0-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:451daa98463b7695b0a30aa56bf637831ea559e7b8101ac2ef6382e8eb15e29c", size = 248238, upload-time = "2026-04-09T16:06:02.537Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/3c/2d34365177f412c9e19c0a29f969d70f5343f27634b76b765a54d8b27705/librt-0.9.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:928bd06eca2c2bbf4349e5b817f837509b0604342e65a502de1d50a7570afd15", size = 269457, upload-time = "2026-04-09T16:06:03.833Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/cd/de45b239ea3bdf626f982a00c14bfcf2e12d261c510ba7db62c5969a27cd/librt-0.9.0-cp314-cp314t-win32.whl", hash = "sha256:a9c63e04d003bc0fb6a03b348018b9a3002f98268200e22cc80f146beac5dc40", size = 52453, upload-time = "2026-04-09T16:06:05.229Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/f9/bfb32ae428aa75c0c533915622176f0a17d6da7b72b5a3c6363685914f70/librt-0.9.0-cp314-cp314t-win_amd64.whl", hash = "sha256:f162af66a2ed3f7d1d161a82ca584efd15acd9c1cff190a373458c32f7d42118", size = 60044, upload-time = "2026-04-09T16:06:06.398Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/47/7d70414bcdbb3bc1f458a8d10558f00bbfdb24e5a11740fc8197e12c3255/librt-0.9.0-cp314-cp314t-win_arm64.whl", hash = "sha256:a4b25c6c25cac5d0d9d6d6da855195b254e0021e513e0249f0e3b444dc6e0e61", size = 50009, upload-time = "2026-04-09T16:06:07.995Z" },
+]
+
+[[package]]
+name = "mypy"
+version = "1.20.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "librt", marker = "platform_python_implementation != 'PyPy'" },
+    { name = "mypy-extensions" },
+    { name = "pathspec" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/04/af/e3d4b3e9ec91a0ff9aabfdb38692952acf49bbb899c2e4c29acb3a6da3ae/mypy-1.20.2.tar.gz", hash = "sha256:e8222c26daaafd9e8626dec58ae36029f82585890589576f769a650dd20fd665", size = 3817349, upload-time = "2026-04-21T17:12:28.473Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/71/4e/7560e4528db9e9b147e4c0f22660466bf30a0a1fe3d63d1b9d3b0fd354ee/mypy-1.20.2-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:4dbfcf869f6b0517f70cf0030ba6ea1d6645e132337a7d5204a18d8d5636c02b", size = 14539393, upload-time = "2026-04-21T17:07:12.52Z" },
+    { url = "https://files.pythonhosted.org/packages/32/d9/34a5efed8124f5a9234f55ac6a4ced4201e2c5b81e1109c49ad23190ec8c/mypy-1.20.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:4b6481b228d072315b053210b01ac320e1be243dc17f9e5887ef167f23f5fae4", size = 13361642, upload-time = "2026-04-21T17:06:53.742Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/14/eb377acf78c03c92d566a1510cda8137348215b5335085ef662ab82ecd3a/mypy-1.20.2-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:34397cdced6b90b836e38182076049fdb41424322e0b0728c946b0939ebdf9f6", size = 13740347, upload-time = "2026-04-21T17:12:04.73Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/94/7e4634a32b641aa1c112422eed1bbece61ee16205f674190e8b536f884de/mypy-1.20.2-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a5da6976f20cae27059ea8d0c86e7cef3de720e04c4bb9ee18e3690fdb792066", size = 14734042, upload-time = "2026-04-21T17:07:43.16Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/f3/f7e62395cb7f434541b4491a01149a4439e28ace4c0c632bbf5431e92d1f/mypy-1.20.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:56908d7e08318d39f85b1f0c6cfd47b0cac1a130da677630dac0de3e0623e102", size = 14964958, upload-time = "2026-04-21T17:11:00.665Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/0d/47e3c3a0ec2a876e35aeac365df3cac7776c36bbd4ed18cc521e1b9d255b/mypy-1.20.2-cp312-cp312-win_amd64.whl", hash = "sha256:d52ad8d78522da1d308789df651ee5379088e77c76cb1994858d40a426b343b9", size = 10911340, upload-time = "2026-04-21T17:10:49.179Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/b2/6c852d72e0ea8b01f49da817fb52539993cde327e7d010e0103dc12d0dac/mypy-1.20.2-cp312-cp312-win_arm64.whl", hash = "sha256:785b08db19c9f214dc37d65f7c165d19a30fcecb48abfa30f31b01b5acaabb58", size = 9833947, upload-time = "2026-04-21T17:09:05.267Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/c4/b93812d3a192c9bcf5df405bd2f30277cd0e48106a14d1023c7f6ed6e39b/mypy-1.20.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:edfbfca868cdd6bd8d974a60f8a3682f5565d3f5c99b327640cedd24c4264026", size = 14524670, upload-time = "2026-04-21T17:10:30.737Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/47/42c122501bff18eaf1e8f457f5c017933452d8acdc52918a9f59f6812955/mypy-1.20.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:e2877a02380adfcdbc69071a0f74d6e9dbbf593c0dc9d174e1f223ffd5281943", size = 13336218, upload-time = "2026-04-21T17:08:44.069Z" },
+    { url = "https://files.pythonhosted.org/packages/92/8f/75bbc92f41725fbd585fb17b440b1119b576105df1013622983e18640a93/mypy-1.20.2-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7488448de6007cd5177c6cea0517ac33b4c0f5ee9b5e9f2be51ce75511a85517", size = 13724906, upload-time = "2026-04-21T17:08:01.02Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/32/4c49da27a606167391ff0c39aa955707a00edc500572e562f7c36c08a71f/mypy-1.20.2-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bb9c2fa06887e21d6a3a868762acb82aec34e2c6fd0174064f27c93ede68ad15", size = 14726046, upload-time = "2026-04-21T17:11:22.354Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/fc/4e354a1bd70216359deb0c9c54847ee6b32ef78dfb09f5131ff99b494078/mypy-1.20.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:9d56a78b646f2e3daa865bc70cd5ec5a46c50045801ca8ff17a0c43abc97e3ee", size = 14955587, upload-time = "2026-04-21T17:12:16.033Z" },
+    { url = "https://files.pythonhosted.org/packages/62/b2/c0f2056e9eb8f08c62cafd9715e4584b89132bdc832fcf85d27d07b5f3e5/mypy-1.20.2-cp313-cp313-win_amd64.whl", hash = "sha256:2a4102b03bb7481d9a91a6da8d174740c9c8c4401024684b9ca3b7cc5e49852f", size = 10922681, upload-time = "2026-04-21T17:06:35.842Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/14/065e333721f05de8ef683d0aa804c23026bcc287446b61cac657b902ccac/mypy-1.20.2-cp313-cp313-win_arm64.whl", hash = "sha256:a95a9248b0c6fd933a442c03c3b113c3b61320086b88e2c444676d3fd1ca3330", size = 9830560, upload-time = "2026-04-21T17:07:51.023Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/d1/b4ec96b0ecc620a4443570c6e95c867903428cfcde4206518eafdd5880c3/mypy-1.20.2-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:419413398fe250aae057fd2fe50166b61077083c9b82754c341cf4fd73038f30", size = 14524561, upload-time = "2026-04-21T17:06:27.325Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/63/d2c2ff4fa66bc49477d32dfa26e8a167ba803ea6a69c5efb416036909d30/mypy-1.20.2-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:e73c07f23009962885c197ccb9b41356a30cc0e5a1d0c2ea8fd8fb1362d7f924", size = 13363883, upload-time = "2026-04-21T17:11:11.239Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/56/983916806bf4eddeaaa2c9230903c3669c6718552a921154e1c5182c701f/mypy-1.20.2-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0c64e5973df366b747646fc98da921f9d6eba9716d57d1db94a83c026a08e0fb", size = 13742945, upload-time = "2026-04-21T17:08:34.181Z" },
+    { url = "https://files.pythonhosted.org/packages/19/65/0cd9285ab010ee8214c83d67c6b49417c40d86ce46f1aa109457b5a9b8d7/mypy-1.20.2-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5a65aa591af023864fd08a97da9974e919452cfe19cb146c8a5dc692626445dc", size = 14706163, upload-time = "2026-04-21T17:05:15.51Z" },
+    { url = "https://files.pythonhosted.org/packages/94/97/48ff3b297cafcc94d185243a9190836fb1b01c1b0918fff64e941e973cc9/mypy-1.20.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:4fef51b01e638974a6e69885687e9bd40c8d1e09a6cd291cca0619625cf1f558", size = 14938677, upload-time = "2026-04-21T17:05:39.562Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/a1/1b4233d255bdd0b38a1f284feeb1c143ca508c19184964e22f8d837ec851/mypy-1.20.2-cp314-cp314-win_amd64.whl", hash = "sha256:913485a03f1bcf5d279409a9d2b9ed565c151f61c09f29991e5faa14033da4c8", size = 11089322, upload-time = "2026-04-21T17:06:44.29Z" },
+    { url = "https://files.pythonhosted.org/packages/78/c2/ce7ee2ba36aeb954ba50f18fa25d9c1188578654b97d02a66a15b6f09531/mypy-1.20.2-cp314-cp314-win_arm64.whl", hash = "sha256:c3bae4f855d965b5453784300c12ffc63a548304ac7f99e55d4dc7c898673aa3", size = 10017775, upload-time = "2026-04-21T17:07:20.732Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/a1/9d93a7d0b5859af0ead82b4888b46df6c8797e1bc5e1e262a08518c6d48e/mypy-1.20.2-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:2de3dcea53babc1c3237a19002bc3d228ce1833278f093b8d619e06e7cc79609", size = 15549002, upload-time = "2026-04-21T17:08:23.107Z" },
+    { url = "https://files.pythonhosted.org/packages/00/d2/09a6a10ee1bf0008f6c144d9676f2ca6a12512151b4e0ad0ff6c4fac5337/mypy-1.20.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:52b176444e2e5054dfcbcb8c75b0b719865c96247b37407184bbfca5c353f2c2", size = 14401942, upload-time = "2026-04-21T17:07:31.837Z" },
+    { url = "https://files.pythonhosted.org/packages/57/da/9594b75c3c019e805250bed3583bdf4443ff9e6ef08f97e39ae308cb06f2/mypy-1.20.2-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:688c3312e5dadb573a2c69c82af3a298d43ecf9e6d264e0f95df960b5f6ac19c", size = 15041649, upload-time = "2026-04-21T17:09:34.653Z" },
+    { url = "https://files.pythonhosted.org/packages/97/77/f75a65c278e6e8eba2071f7f5a90481891053ecc39878cc444634d892abe/mypy-1.20.2-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:29752dbbf8cc53f89f6ac096d363314333045c257c9c75cbd189ca2de0455744", size = 15864588, upload-time = "2026-04-21T17:11:44.936Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/46/1a4e1c66e96c1a3246ddf5403d122ac9b0a8d2b7e65730b9d6533ba7a6d3/mypy-1.20.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:803203d2b6ea644982c644895c2f78b28d0e208bba7b27d9b921e0ec5eb207c6", size = 16093956, upload-time = "2026-04-21T17:10:17.683Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/2c/78a8851264dec38cd736ca5b8bc9380674df0dd0be7792f538916157716c/mypy-1.20.2-cp314-cp314t-win_amd64.whl", hash = "sha256:9bcb8aa397ff0093c824182fd76a935a9ba7ad097fcbef80ae89bf6c1731d8ec", size = 12568661, upload-time = "2026-04-21T17:11:54.473Z" },
+    { url = "https://files.pythonhosted.org/packages/83/01/cd7318aa03493322ce275a0e14f4f52b8896335e4e79d4fb8153a7ad2b77/mypy-1.20.2-cp314-cp314t-win_arm64.whl", hash = "sha256:e061b58443f1736f8a37c48978d7ab581636d6ab03e3d4f99e3fa90463bb9382", size = 10389240, upload-time = "2026-04-21T17:09:42.719Z" },
+    { url = "https://files.pythonhosted.org/packages/28/9a/f23c163e25b11074188251b0b5a0342625fc1cdb6af604757174fa9acc9b/mypy-1.20.2-py3-none-any.whl", hash = "sha256:a94c5a76ab46c5e6257c7972b6c8cff0574201ca7dc05647e33e795d78680563", size = 2637314, upload-time = "2026-04-21T17:05:54.5Z" },
+]
+
+[[package]]
+name = "mypy-extensions"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/6e/371856a3fb9d31ca8dac321cda606860fa4548858c0cc45d9d1d4ca2628b/mypy_extensions-1.1.0.tar.gz", hash = "sha256:52e68efc3284861e772bbcd66823fde5ae21fd2fdb51c62a211403730b916558", size = 6343, upload-time = "2025-04-22T14:54:24.164Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/79/7b/2c79738432f5c924bef5071f933bcc9efd0473bac3b4aa584a6f7c1c8df8/mypy_extensions-1.1.0-py3-none-any.whl", hash = "sha256:1be4cccdb0f2482337c4743e60421de3a356cd97508abadd57d47403e94f5505", size = 4963, upload-time = "2025-04-22T14:54:22.983Z" },
+]
+
+[[package]]
+name = "netbox-dhcp-kea-plugin"
+version = "0.7.3"
+source = { editable = "." }
+
+[package.optional-dependencies]
+dev = [
+    { name = "check-manifest" },
+    { name = "django-stubs", extra = ["compatible-mypy"] },
+    { name = "mypy" },
+    { name = "pip" },
+    { name = "ruff" },
+]
+test = [
+    { name = "pre-commit" },
+    { name = "pytest" },
+    { name = "pytest-cov" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "check-manifest", marker = "extra == 'dev'", specifier = "==0.49" },
+    { name = "django-stubs", extras = ["compatible-mypy"], marker = "extra == 'dev'" },
+    { name = "mypy", marker = "extra == 'dev'" },
+    { name = "pip", marker = "extra == 'dev'", specifier = ">=24.0" },
+    { name = "pre-commit", marker = "extra == 'test'", specifier = "==3.7.0" },
+    { name = "pytest", marker = "extra == 'test'", specifier = "==8.1.1" },
+    { name = "pytest-cov", marker = "extra == 'test'", specifier = ">=4.1.0" },
+    { name = "ruff", marker = "extra == 'dev'" },
+]
+provides-extras = ["test", "dev"]
+
+[[package]]
+name = "nodeenv"
+version = "1.10.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/24/bf/d1bda4f6168e0b2e9e5958945e01910052158313224ada5ce1fb2e1113b8/nodeenv-1.10.0.tar.gz", hash = "sha256:996c191ad80897d076bdfba80a41994c2b47c68e224c542b48feba42ba00f8bb", size = 55611, upload-time = "2025-12-20T14:08:54.006Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/b2/d0896bdcdc8d28a7fc5717c305f1a861c26e18c05047949fb371034d98bd/nodeenv-1.10.0-py2.py3-none-any.whl", hash = "sha256:5bb13e3eed2923615535339b3c620e76779af4cb4c6a90deccc9e36b274d3827", size = 23438, upload-time = "2025-12-20T14:08:52.782Z" },
+]
+
+[[package]]
+name = "packaging"
+version = "26.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/f1/e7a6dd94a8d4a5626c03e4e99c87f241ba9e350cd9e6d75123f992427270/packaging-26.2.tar.gz", hash = "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661", size = 228134, upload-time = "2026-04-24T20:15:23.917Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl", hash = "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e", size = 100195, upload-time = "2026-04-24T20:15:22.081Z" },
+]
+
+[[package]]
+name = "pathspec"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2e/17/9c3094b822982b9f1ea666d8580ce59000f61f87c1663556fb72031ad9ec/pathspec-1.1.0.tar.gz", hash = "sha256:f5d7c555da02fd8dde3e4a2354b6aba817a89112fa8f333f7917a2a4834dd080", size = 133918, upload-time = "2026-04-23T01:46:22.298Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fa/c9/8eed0486f074e9f1ca7f8ce5ad663e65f12fdab344028d658fa1b03d35e0/pathspec-1.1.0-py3-none-any.whl", hash = "sha256:574b128f7456bd899045ccd142dd446af7e6cfd0072d63ad73fbc55fbb4aaa42", size = 56264, upload-time = "2026-04-23T01:46:20.606Z" },
+]
+
+[[package]]
+name = "pip"
+version = "26.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/48/83/0d7d4e9efe3344b8e2fe25d93be44f64b65364d3c8d7bc6dc90198d5422e/pip-26.0.1.tar.gz", hash = "sha256:c4037d8a277c89b320abe636d59f91e6d0922d08a05b60e85e53b296613346d8", size = 1812747, upload-time = "2026-02-05T02:20:18.702Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/de/f0/c81e05b613866b76d2d1066490adf1a3dbc4ee9d9c839961c3fc8a6997af/pip-26.0.1-py3-none-any.whl", hash = "sha256:bdb1b08f4274833d62c1aa29e20907365a2ceb950410df15fc9521bad440122b", size = 1787723, upload-time = "2026-02-05T02:20:16.416Z" },
+]
+
+[[package]]
+name = "platformdirs"
+version = "4.9.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9f/4a/0883b8e3802965322523f0b200ecf33d31f10991d0401162f4b23c698b42/platformdirs-4.9.6.tar.gz", hash = "sha256:3bfa75b0ad0db84096ae777218481852c0ebc6c727b3168c1b9e0118e458cf0a", size = 29400, upload-time = "2026-04-09T00:04:10.812Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/75/a6/a0a304dc33b49145b21f4808d763822111e67d1c3a32b524a1baf947b6e1/platformdirs-4.9.6-py3-none-any.whl", hash = "sha256:e61adb1d5e5cb3441b4b7710bea7e4c12250ca49439228cc1021c00dcfac0917", size = 21348, upload-time = "2026-04-09T00:04:09.463Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "pre-commit"
+version = "3.7.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cfgv" },
+    { name = "identify" },
+    { name = "nodeenv" },
+    { name = "pyyaml" },
+    { name = "virtualenv" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/60/62/691bb4109735ea4b8eb69f4a68110ece4c7ec4a7ce0144996e7302eb5eef/pre_commit-3.7.0.tar.gz", hash = "sha256:e209d61b8acdcf742404408531f0c37d49d2c734fd7cff2d6076083d191cb060", size = 177305, upload-time = "2024-03-24T17:37:47.756Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/53/1a/1870d52d0d86d534d4d5f7a58e65d40a4610b57e13309917faa9e62818fe/pre_commit-3.7.0-py2.py3-none-any.whl", hash = "sha256:5eae9e10c2b5ac51577c3452ec0a490455c45a0533f7960f993a0d01e59decab", size = 204250, upload-time = "2024-03-24T17:37:45.887Z" },
+]
+
+[[package]]
+name = "pyproject-hooks"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e7/82/28175b2414effca1cdac8dc99f76d660e7a4fb0ceefa4b4ab8f5f6742925/pyproject_hooks-1.2.0.tar.gz", hash = "sha256:1e859bd5c40fae9448642dd871adf459e5e2084186e8d2c2a79a824c970da1f8", size = 19228, upload-time = "2024-09-29T09:24:13.293Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bd/24/12818598c362d7f300f18e74db45963dbcb85150324092410c8b49405e42/pyproject_hooks-1.2.0-py3-none-any.whl", hash = "sha256:9e5c6bfa8dcc30091c74b0cf803c81fdd29d94f01992a7707bc97babb1141913", size = 10216, upload-time = "2024-09-29T09:24:11.978Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "8.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/30/b7/7d44bbc04c531dcc753056920e0988032e5871ac674b5a84cb979de6e7af/pytest-8.1.1.tar.gz", hash = "sha256:ac978141a75948948817d360297b7aae0fcb9d6ff6bc9ec6d514b85d5a65c044", size = 1409703, upload-time = "2024-03-09T11:51:08.012Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4d/7e/c79cecfdb6aa85c6c2e3cf63afc56d0f165f24f5c66c03c695c4d9b84756/pytest-8.1.1-py3-none-any.whl", hash = "sha256:2a8386cfc11fa9d2c50ee7b2a57e7d898ef90470a7a34c4b949ff59662bb78b7", size = 337359, upload-time = "2024-03-09T11:51:04.858Z" },
+]
+
+[[package]]
+name = "pytest-cov"
+version = "7.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "coverage" },
+    { name = "pluggy" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/51/a849f96e117386044471c8ec2bd6cfebacda285da9525c9106aeb28da671/pytest_cov-7.1.0.tar.gz", hash = "sha256:30674f2b5f6351aa09702a9c8c364f6a01c27aae0c1366ae8016160d1efc56b2", size = 55592, upload-time = "2026-03-21T20:11:16.284Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9d/7a/d968e294073affff457b041c2be9868a40c1c71f4a35fcc1e45e5493067b/pytest_cov-7.1.0-py3-none-any.whl", hash = "sha256:a0461110b7865f9a271aa1b51e516c9a95de9d696734a2f71e3e78f46e1d4678", size = 22876, upload-time = "2026-03-21T20:11:14.438Z" },
+]
+
+[[package]]
+name = "python-discovery"
+version = "1.2.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "filelock" },
+    { name = "platformdirs" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/de/ef/3bae0e537cfe91e8431efcba4434463d2c5a65f5a89edd47c6cf2f03c55f/python_discovery-1.2.2.tar.gz", hash = "sha256:876e9c57139eb757cb5878cbdd9ae5379e5d96266c99ef731119e04fffe533bb", size = 58872, upload-time = "2026-04-07T17:28:49.249Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d8/db/795879cc3ddfe338599bddea6388cc5100b088db0a4caf6e6c1af1c27e04/python_discovery-1.2.2-py3-none-any.whl", hash = "sha256:e1ae95d9af875e78f15e19aed0c6137ab1bb49c200f21f5061786490c9585c7a", size = 31894, upload-time = "2026-04-07T17:28:48.09Z" },
+]
+
+[[package]]
+name = "pyyaml"
+version = "6.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/05/8e/961c0007c59b8dd7729d542c61a4d537767a59645b82a0b521206e1e25c2/pyyaml-6.0.3.tar.gz", hash = "sha256:d76623373421df22fb4cf8817020cbb7ef15c725b9d5e45f17e189bfc384190f", size = 130960, upload-time = "2025-09-25T21:33:16.546Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/33/422b98d2195232ca1826284a76852ad5a86fe23e31b009c9886b2d0fb8b2/pyyaml-6.0.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:7f047e29dcae44602496db43be01ad42fc6f1cc0d8cd6c83d342306c32270196", size = 182063, upload-time = "2025-09-25T21:32:11.445Z" },
+    { url = "https://files.pythonhosted.org/packages/89/a0/6cf41a19a1f2f3feab0e9c0b74134aa2ce6849093d5517a0c550fe37a648/pyyaml-6.0.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:fc09d0aa354569bc501d4e787133afc08552722d3ab34836a80547331bb5d4a0", size = 173973, upload-time = "2025-09-25T21:32:12.492Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/23/7a778b6bd0b9a8039df8b1b1d80e2e2ad78aa04171592c8a5c43a56a6af4/pyyaml-6.0.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9149cad251584d5fb4981be1ecde53a1ca46c891a79788c0df828d2f166bda28", size = 775116, upload-time = "2025-09-25T21:32:13.652Z" },
+    { url = "https://files.pythonhosted.org/packages/65/30/d7353c338e12baef4ecc1b09e877c1970bd3382789c159b4f89d6a70dc09/pyyaml-6.0.3-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:5fdec68f91a0c6739b380c83b951e2c72ac0197ace422360e6d5a959d8d97b2c", size = 844011, upload-time = "2025-09-25T21:32:15.21Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/9d/b3589d3877982d4f2329302ef98a8026e7f4443c765c46cfecc8858c6b4b/pyyaml-6.0.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ba1cc08a7ccde2d2ec775841541641e4548226580ab850948cbfda66a1befcdc", size = 807870, upload-time = "2025-09-25T21:32:16.431Z" },
+    { url = "https://files.pythonhosted.org/packages/05/c0/b3be26a015601b822b97d9149ff8cb5ead58c66f981e04fedf4e762f4bd4/pyyaml-6.0.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:8dc52c23056b9ddd46818a57b78404882310fb473d63f17b07d5c40421e47f8e", size = 761089, upload-time = "2025-09-25T21:32:17.56Z" },
+    { url = "https://files.pythonhosted.org/packages/be/8e/98435a21d1d4b46590d5459a22d88128103f8da4c2d4cb8f14f2a96504e1/pyyaml-6.0.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:41715c910c881bc081f1e8872880d3c650acf13dfa8214bad49ed4cede7c34ea", size = 790181, upload-time = "2025-09-25T21:32:18.834Z" },
+    { url = "https://files.pythonhosted.org/packages/74/93/7baea19427dcfbe1e5a372d81473250b379f04b1bd3c4c5ff825e2327202/pyyaml-6.0.3-cp312-cp312-win32.whl", hash = "sha256:96b533f0e99f6579b3d4d4995707cf36df9100d67e0c8303a0c55b27b5f99bc5", size = 137658, upload-time = "2025-09-25T21:32:20.209Z" },
+    { url = "https://files.pythonhosted.org/packages/86/bf/899e81e4cce32febab4fb42bb97dcdf66bc135272882d1987881a4b519e9/pyyaml-6.0.3-cp312-cp312-win_amd64.whl", hash = "sha256:5fcd34e47f6e0b794d17de1b4ff496c00986e1c83f7ab2fb8fcfe9616ff7477b", size = 154003, upload-time = "2025-09-25T21:32:21.167Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/08/67bd04656199bbb51dbed1439b7f27601dfb576fb864099c7ef0c3e55531/pyyaml-6.0.3-cp312-cp312-win_arm64.whl", hash = "sha256:64386e5e707d03a7e172c0701abfb7e10f0fb753ee1d773128192742712a98fd", size = 140344, upload-time = "2025-09-25T21:32:22.617Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/11/0fd08f8192109f7169db964b5707a2f1e8b745d4e239b784a5a1dd80d1db/pyyaml-6.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:8da9669d359f02c0b91ccc01cac4a67f16afec0dac22c2ad09f46bee0697eba8", size = 181669, upload-time = "2025-09-25T21:32:23.673Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/16/95309993f1d3748cd644e02e38b75d50cbc0d9561d21f390a76242ce073f/pyyaml-6.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:2283a07e2c21a2aa78d9c4442724ec1eb15f5e42a723b99cb3d822d48f5f7ad1", size = 173252, upload-time = "2025-09-25T21:32:25.149Z" },
+    { url = "https://files.pythonhosted.org/packages/50/31/b20f376d3f810b9b2371e72ef5adb33879b25edb7a6d072cb7ca0c486398/pyyaml-6.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ee2922902c45ae8ccada2c5b501ab86c36525b883eff4255313a253a3160861c", size = 767081, upload-time = "2025-09-25T21:32:26.575Z" },
+    { url = "https://files.pythonhosted.org/packages/49/1e/a55ca81e949270d5d4432fbbd19dfea5321eda7c41a849d443dc92fd1ff7/pyyaml-6.0.3-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a33284e20b78bd4a18c8c2282d549d10bc8408a2a7ff57653c0cf0b9be0afce5", size = 841159, upload-time = "2025-09-25T21:32:27.727Z" },
+    { url = "https://files.pythonhosted.org/packages/74/27/e5b8f34d02d9995b80abcef563ea1f8b56d20134d8f4e5e81733b1feceb2/pyyaml-6.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0f29edc409a6392443abf94b9cf89ce99889a1dd5376d94316ae5145dfedd5d6", size = 801626, upload-time = "2025-09-25T21:32:28.878Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/11/ba845c23988798f40e52ba45f34849aa8a1f2d4af4b798588010792ebad6/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:f7057c9a337546edc7973c0d3ba84ddcdf0daa14533c2065749c9075001090e6", size = 753613, upload-time = "2025-09-25T21:32:30.178Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/e0/7966e1a7bfc0a45bf0a7fb6b98ea03fc9b8d84fa7f2229e9659680b69ee3/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:eda16858a3cab07b80edaf74336ece1f986ba330fdb8ee0d6c0d68fe82bc96be", size = 794115, upload-time = "2025-09-25T21:32:31.353Z" },
+    { url = "https://files.pythonhosted.org/packages/de/94/980b50a6531b3019e45ddeada0626d45fa85cbe22300844a7983285bed3b/pyyaml-6.0.3-cp313-cp313-win32.whl", hash = "sha256:d0eae10f8159e8fdad514efdc92d74fd8d682c933a6dd088030f3834bc8e6b26", size = 137427, upload-time = "2025-09-25T21:32:32.58Z" },
+    { url = "https://files.pythonhosted.org/packages/97/c9/39d5b874e8b28845e4ec2202b5da735d0199dbe5b8fb85f91398814a9a46/pyyaml-6.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:79005a0d97d5ddabfeeea4cf676af11e647e41d81c9a7722a193022accdb6b7c", size = 154090, upload-time = "2025-09-25T21:32:33.659Z" },
+    { url = "https://files.pythonhosted.org/packages/73/e8/2bdf3ca2090f68bb3d75b44da7bbc71843b19c9f2b9cb9b0f4ab7a5a4329/pyyaml-6.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:5498cd1645aa724a7c71c8f378eb29ebe23da2fc0d7a08071d89469bf1d2defb", size = 140246, upload-time = "2025-09-25T21:32:34.663Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/8c/f4bd7f6465179953d3ac9bc44ac1a8a3e6122cf8ada906b4f96c60172d43/pyyaml-6.0.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:8d1fab6bb153a416f9aeb4b8763bc0f22a5586065f86f7664fc23339fc1c1fac", size = 181814, upload-time = "2025-09-25T21:32:35.712Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/9c/4d95bb87eb2063d20db7b60faa3840c1b18025517ae857371c4dd55a6b3a/pyyaml-6.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:34d5fcd24b8445fadc33f9cf348c1047101756fd760b4dacb5c3e99755703310", size = 173809, upload-time = "2025-09-25T21:32:36.789Z" },
+    { url = "https://files.pythonhosted.org/packages/92/b5/47e807c2623074914e29dabd16cbbdd4bf5e9b2db9f8090fa64411fc5382/pyyaml-6.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:501a031947e3a9025ed4405a168e6ef5ae3126c59f90ce0cd6f2bfc477be31b7", size = 766454, upload-time = "2025-09-25T21:32:37.966Z" },
+    { url = "https://files.pythonhosted.org/packages/02/9e/e5e9b168be58564121efb3de6859c452fccde0ab093d8438905899a3a483/pyyaml-6.0.3-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:b3bc83488de33889877a0f2543ade9f70c67d66d9ebb4ac959502e12de895788", size = 836355, upload-time = "2025-09-25T21:32:39.178Z" },
+    { url = "https://files.pythonhosted.org/packages/88/f9/16491d7ed2a919954993e48aa941b200f38040928474c9e85ea9e64222c3/pyyaml-6.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c458b6d084f9b935061bc36216e8a69a7e293a2f1e68bf956dcd9e6cbcd143f5", size = 794175, upload-time = "2025-09-25T21:32:40.865Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/3f/5989debef34dc6397317802b527dbbafb2b4760878a53d4166579111411e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7c6610def4f163542a622a73fb39f534f8c101d690126992300bf3207eab9764", size = 755228, upload-time = "2025-09-25T21:32:42.084Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/ce/af88a49043cd2e265be63d083fc75b27b6ed062f5f9fd6cdc223ad62f03e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:5190d403f121660ce8d1d2c1bb2ef1bd05b5f68533fc5c2ea899bd15f4399b35", size = 789194, upload-time = "2025-09-25T21:32:43.362Z" },
+    { url = "https://files.pythonhosted.org/packages/23/20/bb6982b26a40bb43951265ba29d4c246ef0ff59c9fdcdf0ed04e0687de4d/pyyaml-6.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:4a2e8cebe2ff6ab7d1050ecd59c25d4c8bd7e6f400f5f82b96557ac0abafd0ac", size = 156429, upload-time = "2025-09-25T21:32:57.844Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/f4/a4541072bb9422c8a883ab55255f918fa378ecf083f5b85e87fc2b4eda1b/pyyaml-6.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:93dda82c9c22deb0a405ea4dc5f2d0cda384168e466364dec6255b293923b2f3", size = 143912, upload-time = "2025-09-25T21:32:59.247Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/f9/07dd09ae774e4616edf6cda684ee78f97777bdd15847253637a6f052a62f/pyyaml-6.0.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:02893d100e99e03eda1c8fd5c441d8c60103fd175728e23e431db1b589cf5ab3", size = 189108, upload-time = "2025-09-25T21:32:44.377Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/78/8d08c9fb7ce09ad8c38ad533c1191cf27f7ae1effe5bb9400a46d9437fcf/pyyaml-6.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:c1ff362665ae507275af2853520967820d9124984e0f7466736aea23d8611fba", size = 183641, upload-time = "2025-09-25T21:32:45.407Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/5b/3babb19104a46945cf816d047db2788bcaf8c94527a805610b0289a01c6b/pyyaml-6.0.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6adc77889b628398debc7b65c073bcb99c4a0237b248cacaf3fe8a557563ef6c", size = 831901, upload-time = "2025-09-25T21:32:48.83Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/cc/dff0684d8dc44da4d22a13f35f073d558c268780ce3c6ba1b87055bb0b87/pyyaml-6.0.3-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a80cb027f6b349846a3bf6d73b5e95e782175e52f22108cfa17876aaeff93702", size = 861132, upload-time = "2025-09-25T21:32:50.149Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/5e/f77dc6b9036943e285ba76b49e118d9ea929885becb0a29ba8a7c75e29fe/pyyaml-6.0.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:00c4bdeba853cc34e7dd471f16b4114f4162dc03e6b7afcc2128711f0eca823c", size = 839261, upload-time = "2025-09-25T21:32:51.808Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/88/a9db1376aa2a228197c58b37302f284b5617f56a5d959fd1763fb1675ce6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:66e1674c3ef6f541c35191caae2d429b967b99e02040f5ba928632d9a7f0f065", size = 805272, upload-time = "2025-09-25T21:32:52.941Z" },
+    { url = "https://files.pythonhosted.org/packages/da/92/1446574745d74df0c92e6aa4a7b0b3130706a4142b2d1a5869f2eaa423c6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:16249ee61e95f858e83976573de0f5b2893b3677ba71c9dd36b9cf8be9ac6d65", size = 829923, upload-time = "2025-09-25T21:32:54.537Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/7a/1c7270340330e575b92f397352af856a8c06f230aa3e76f86b39d01b416a/pyyaml-6.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4ad1906908f2f5ae4e5a8ddfce73c320c2a1429ec52eafd27138b7f1cbe341c9", size = 174062, upload-time = "2025-09-25T21:32:55.767Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/12/de94a39c2ef588c7e6455cfbe7343d3b2dc9d6b6b2f40c4c6565744c873d/pyyaml-6.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b", size = 149341, upload-time = "2025-09-25T21:32:56.828Z" },
+]
+
+[[package]]
+name = "ruff"
+version = "0.15.12"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/99/43/3291f1cc9106f4c63bdce7a8d0df5047fe8422a75b091c16b5e9355e0b11/ruff-0.15.12.tar.gz", hash = "sha256:ecea26adb26b4232c0c2ca19ccbc0083a68344180bba2a600605538ce51a40a6", size = 4643852, upload-time = "2026-04-24T18:17:14.305Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c3/6e/e78ffb61d4686f3d96ba3df2c801161843746dcbcbb17a1e927d4829312b/ruff-0.15.12-py3-none-linux_armv6l.whl", hash = "sha256:f86f176e188e94d6bdbc09f09bfd9dc729059ad93d0e7390b5a73efe19f8861c", size = 10640713, upload-time = "2026-04-24T18:17:22.841Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/08/a317bc231fb9e7b93e4ef3089501e51922ff88d6936ce5cf870c4fe55419/ruff-0.15.12-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:e3bcd123364c3770b8e1b7baaf343cc99a35f197c5c6e8af79015c666c423a6c", size = 11069267, upload-time = "2026-04-24T18:17:30.105Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/a4/f828e9718d3dce1f5f11c39c4f65afd32783c8b2aebb2e3d259e492c47bd/ruff-0.15.12-py3-none-macosx_11_0_arm64.whl", hash = "sha256:fe87510d000220aa1ed530d4448a7c696a0cae1213e5ec30e5874287b66557b5", size = 10397182, upload-time = "2026-04-24T18:17:07.177Z" },
+    { url = "https://files.pythonhosted.org/packages/71/e0/3310fc6d1b5e1fdea22bf3b1b807c7e187b581021b0d7d4514cccdb5fb71/ruff-0.15.12-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:84a1630093121375a3e2a95b4a6dc7b59e2b4ee76216e32d81aae550a832d002", size = 10758012, upload-time = "2026-04-24T18:16:55.759Z" },
+    { url = "https://files.pythonhosted.org/packages/11/c1/a606911aee04c324ddaa883ae418f3569792fd3c4a10c50e0dd0a2311e1e/ruff-0.15.12-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:fb129f40f114f089ebe0ca56c0d251cf2061b17651d464bb6478dc01e69f11f5", size = 10447479, upload-time = "2026-04-24T18:16:51.677Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/68/4201e8444f0894f21ab4aeeaee68aa4f10b51613514a20d80bd628d57e88/ruff-0.15.12-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b0c862b172d695db7598426b8af465e7e9ac00a3ea2a3630ee67eb82e366aaa6", size = 11234040, upload-time = "2026-04-24T18:17:16.529Z" },
+    { url = "https://files.pythonhosted.org/packages/34/ff/8a6d6cf4ccc23fd67060874e832c18919d1557a0611ebef03fdb01fff11e/ruff-0.15.12-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:2849ea9f3484c3aca43a82f484210370319e7170df4dfe4843395ddf6c57bc33", size = 12087377, upload-time = "2026-04-24T18:17:04.944Z" },
+    { url = "https://files.pythonhosted.org/packages/85/f6/c669cf73f5152f623d34e69866a46d5e6185816b19fcd5b6dd8a2d299922/ruff-0.15.12-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9e77c7e51c07fe396826d5969a5b846d9cd4c402535835fb6e21ce8b28fef847", size = 11367784, upload-time = "2026-04-24T18:17:25.409Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/39/c61d193b8a1daaa8977f7dea9e8d8ba866e02ea7b65d32f6861693aa4c12/ruff-0.15.12-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:83b2f4f2f3b1026b5fb449b467d9264bf22067b600f7b6f41fc5958909f449d0", size = 11344088, upload-time = "2026-04-24T18:17:12.258Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/8d/49afab3645e31e12c590acb6d3b5b69d7aab5b81926dbaf7461f9441f37a/ruff-0.15.12-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:9ba3b8f1afd7e2e43d8943e55f249e13f9682fde09711644a6e7290eb4f3e339", size = 11271770, upload-time = "2026-04-24T18:17:02.457Z" },
+    { url = "https://files.pythonhosted.org/packages/46/06/33f41fe94403e2b755481cdfb9b7ef3e4e0ed031c4581124658d935d52b4/ruff-0.15.12-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:e852ba9fdc890655e1d78f2df1499efbe0e54126bd405362154a75e2bde159c5", size = 10719355, upload-time = "2026-04-24T18:17:27.648Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/59/18aa4e014debbf559670e4048e39260a85c7fcee84acfd761ac01e7b8d35/ruff-0.15.12-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:dd8aed930da53780d22fc70bdf84452c843cf64f8cb4eb38984319c24c5cd5fd", size = 10462758, upload-time = "2026-04-24T18:17:32.347Z" },
+    { url = "https://files.pythonhosted.org/packages/25/e7/cc9f16fd0f3b5fddcbd7ec3d6ae30c8f3fde1047f32a4093a98d633c6570/ruff-0.15.12-py3-none-musllinux_1_2_i686.whl", hash = "sha256:01da3988d225628b709493d7dc67c3b9b12c0210016b08690ef9bd27970b262b", size = 10953498, upload-time = "2026-04-24T18:17:20.674Z" },
+    { url = "https://files.pythonhosted.org/packages/72/7a/a9ba7f98c7a575978698f4230c5e8cc54bbc761af34f560818f933dafa0c/ruff-0.15.12-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:9cae0f92bd5700d1213188b31cd3bdd2b315361296d10b96b8e2337d3d11f53e", size = 11447765, upload-time = "2026-04-24T18:17:09.755Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/f9/0ae446942c846b8266059ad8a30702a35afae55f5cdc54c5adf8d7afdc27/ruff-0.15.12-py3-none-win32.whl", hash = "sha256:d0185894e038d7043ba8fd6aee7499ece6462dc0ea9f1e260c7451807c714c20", size = 10657277, upload-time = "2026-04-24T18:17:18.591Z" },
+    { url = "https://files.pythonhosted.org/packages/33/f1/9614e03e1cdcbf9437570b5400ced8a720b5db22b28d8e0f1bda429f660d/ruff-0.15.12-py3-none-win_amd64.whl", hash = "sha256:c87a162d61ab3adca47c03f7f717c68672edec7d1b5499e652331780fe74950d", size = 11837758, upload-time = "2026-04-24T18:17:00.113Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/98/6beb4b351e472e5f4c4613f7c35a5290b8be2497e183825310c4c3a3984b/ruff-0.15.12-py3-none-win_arm64.whl", hash = "sha256:a538f7a82d061cee7be55542aca1d86d1393d55d81d4fcc314370f4340930d4f", size = 11120821, upload-time = "2026-04-24T18:16:57.979Z" },
+]
+
+[[package]]
+name = "setuptools"
+version = "82.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4f/db/cfac1baf10650ab4d1c111714410d2fbb77ac5a616db26775db562c8fab2/setuptools-82.0.1.tar.gz", hash = "sha256:7d872682c5d01cfde07da7bccc7b65469d3dca203318515ada1de5eda35efbf9", size = 1152316, upload-time = "2026-03-09T12:47:17.221Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9d/76/f789f7a86709c6b087c5a2f52f911838cad707cc613162401badc665acfe/setuptools-82.0.1-py3-none-any.whl", hash = "sha256:a59e362652f08dcd477c78bb6e7bd9d80a7995bc73ce773050228a348ce2e5bb", size = 1006223, upload-time = "2026-03-09T12:47:15.026Z" },
+]
+
+[[package]]
+name = "sqlparse"
+version = "0.5.5"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/90/76/437d71068094df0726366574cf3432a4ed754217b436eb7429415cf2d480/sqlparse-0.5.5.tar.gz", hash = "sha256:e20d4a9b0b8585fdf63b10d30066c7c94c5d7a7ec47c889a2d83a3caa93ff28e", size = 120815, upload-time = "2025-12-19T07:17:45.073Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/49/4b/359f28a903c13438ef59ebeee215fb25da53066db67b305c125f1c6d2a25/sqlparse-0.5.5-py3-none-any.whl", hash = "sha256:12a08b3bf3eec877c519589833aed092e2444e68240a3577e8e26148acc7b1ba", size = 46138, upload-time = "2025-12-19T07:17:46.573Z" },
+]
+
+[[package]]
+name = "types-pyyaml"
+version = "6.0.12.20260408"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/74/73/b759b1e413c31034cc01ecdfb96b38115d0ab4db55a752a3929f0cd449fd/types_pyyaml-6.0.12.20260408.tar.gz", hash = "sha256:92a73f2b8d7f39ef392a38131f76b970f8c66e4c42b3125ae872b7c93b556307", size = 17735, upload-time = "2026-04-08T04:30:50.974Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1c/f0/c391068b86abb708882c6d75a08cd7d25b2c7227dab527b3a3685a3c635b/types_pyyaml-6.0.12.20260408-py3-none-any.whl", hash = "sha256:fbc42037d12159d9c801ebfcc79ebd28335a7c13b08a4cfbc6916df78fee9384", size = 20339, upload-time = "2026-04-08T04:30:50.113Z" },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.15.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
+]
+
+[[package]]
+name = "tzdata"
+version = "2026.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ba/19/1b9b0e29f30c6d35cb345486df41110984ea67ae69dddbc0e8a100999493/tzdata-2026.2.tar.gz", hash = "sha256:9173fde7d80d9018e02a662e168e5a2d04f87c41ea174b139fbef642eda62d10", size = 198254, upload-time = "2026-04-24T15:22:08.651Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ce/e4/dccd7f47c4b64213ac01ef921a1337ee6e30e8c6466046018326977efd95/tzdata-2026.2-py2.py3-none-any.whl", hash = "sha256:bbe9af844f658da81a5f95019480da3a89415801f6cc966806612cc7169bffe7", size = 349321, upload-time = "2026-04-24T15:22:05.876Z" },
+]
+
+[[package]]
+name = "virtualenv"
+version = "21.2.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "distlib" },
+    { name = "filelock" },
+    { name = "platformdirs" },
+    { name = "python-discovery" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0c/98/3a7e644e19cb26133488caff231be390579860bbbb3da35913c49a1d0a46/virtualenv-21.2.4.tar.gz", hash = "sha256:b294ef68192638004d72524ce7ef303e9d0cf5a44c95ce2e54a7500a6381cada", size = 5850742, upload-time = "2026-04-14T22:15:31.438Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/27/8d/edd0bd910ff803c308ee9a6b7778621af0d10252219ad9f19ef4d4982a61/virtualenv-21.2.4-py3-none-any.whl", hash = "sha256:29d21e941795206138d0f22f4e45ff7050e5da6c6472299fb7103318763861ac", size = 5831232, upload-time = "2026-04-14T22:15:29.342Z" },
+]


### PR DESCRIPTION
Models the full kea-dhcp-ddns (D2) configuration surface and the
ddns-* policy knobs that kea-dhcp4/6 render at server, subnet, and
client-class scope. Disabled by default behind enable_ddns; requires
enable_netbox_dns=True (zones and nameservers come from
netbox-plugin-dns; TSIG keys are plugin-local).

New models
- TSIGKey — RFC 2845 keys, pluggable secret_backend (plaintext in v1),
  algorithm-aware auto-generation when input isn't valid base64,
  view_secret_tsigkey perm gates plaintext reveal.
- D2Daemon — listener_mode local (127.0.0.1, deploy per peer for
  HA-pair DDNS redundancy) or remote (shared IPAM-pinned instance).
  Per-daemon /api/.../d2-daemons/<id>/kea-config/ endpoint emits a
  full kea-dhcp-ddns.conf.
- DDNSDomain — binds D2Daemon to a netbox_dns.Zone; forward/reverse
  derived from zone name; nameserver IPs resolved from A/AAAA/CNAME
  at emit time. Multi-zone create form, bulk-edit, quick-add TSIG.
- DDNSPolicy — reusable nullable ddns-* override group attachable at
  server/subnet/client-class scope; only set keys are emitted.

HA precedence
DHCPServer.effective_d2_daemon and effective_ddns_policy: when the
HA relationship sets a value it wins (peers must agree). Sender IP
and port stay per-server. Detail page shows effective values with an
"inherited from HA relationship" badge.